### PR TITLE
- Added config to dedupe messages in the DB producer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added BatchConsumer.
 
+- Added config to dedupe messages in the DB producer.
+- Added config to log messages in the DB producer.
+- Added config to provide a separate logger to the DB producer.
+
 ## [1.0.0] - 2019-09-03
 - Official release of Deimos 1.0!
 

--- a/README.md
+++ b/README.md
@@ -104,11 +104,22 @@ Deimos.configure do |config|
   
   # Change the default backend. See Backends, below.
   config.backend = :db
-  
-  # If the DB backend is being used, specify the number of threads to create
-  # to process the DB messages.
-  config.num_producer_threads = 1
-  
+
+  # Database Backend producer configuration
+ 
+  # Logger for DB producer
+  config.db_producer.logger = Logger.new('/db_producer')
+
+  # List of topics to print full messages for, or :all to print all
+  # topics. This can introduce slowdown since it needs to decode
+  # each message using the schema registry. 
+  config.db_producer.log_topics = ['topic1', 'topic2']
+
+  # List of topics to compact before sending, i.e. only send the
+  # last message with any given key in a batch. This is an optimization
+  # which mirrors what Kafka itself will do with compaction turned on
+  # but only within a single batch. 
+  config.db_producer.compact_topics = ['topic1', 'topic2']
   # Configure the metrics provider (see below).
   config.metrics = Deimos::Metrics::Mock.new({ tags: %w(env:prod my_tag:another_1) })
 

--- a/lib/deimos.rb
+++ b/lib/deimos.rb
@@ -90,7 +90,8 @@ module Deimos
       end
 
       producers = (1..thread_count).map do
-        Deimos::Utils::DbProducer.new(self.config.logger)
+        Deimos::Utils::DbProducer.
+          new(self.config.db_producer.logger || self.config.logger)
       end
       executor = Deimos::Utils::Executor.new(producers,
                                              sleep_seconds: 5,

--- a/lib/deimos/configuration.rb
+++ b/lib/deimos/configuration.rb
@@ -72,10 +72,14 @@ module Deimos
     # @return [Tracing::Provider]
     attr_accessor :tracer
 
+    # @return [Deimos::DbProducerConfiguration]
+    attr_accessor :db_producer
+
     # :nodoc:
     def initialize
       @phobos_config_file = 'config/phobos.yml'
       @publish_backend = :kafka_async
+      @db_producer = DbProducerConfiguration.new
     end
 
     # @param other_config [Configuration]
@@ -85,6 +89,24 @@ module Deimos
       return true if phobos_keys.any? { |key| self.send(key) != other_config.send(key) }
 
       other_config.logger != self.logger
+    end
+  end
+
+  # Sub-class for DB producer configs.
+  class DbProducerConfiguration
+    # @return [Logger]
+    attr_accessor :logger
+    # @return [Symbol|Array<String>] A list of topics to log all messages, or
+    # :all to log all topics.
+    attr_accessor :log_topics
+    # @return [Symbol|Array<String>] A list of topics to compact messages for
+    # before sending, or :all to compact all keyed messages.
+    attr_accessor :compact_topics
+
+    # :nodoc:
+    def initialize
+      @log_topics = []
+      @compact_topics = []
     end
   end
 end

--- a/lib/deimos/utils/db_producer.rb
+++ b/lib/deimos/utils/db_producer.rb
@@ -16,6 +16,11 @@ module Deimos
         @logger.push_tags("DbProducer #{@id}") if @logger.respond_to?(:push_tags)
       end
 
+      # @return [Deimos::DbProducerConfig]
+      def config
+        Deimos.config.db_producer
+      end
+
       # Start the poll.
       def start
         @logger.info('Starting...')
@@ -60,37 +65,54 @@ module Deimos
           return
         end
         @current_topic = topic
-        messages = retrieve_messages
 
-        while messages.any?
-          @logger.debug do
-            decoder = messages.first.decoder
-            "DB producer: Topic #{topic} Producing messages: #{messages.map { |m| m.decoded_message(decoder) }}"
-          end
-          Deimos.instrument('db_producer.produce', topic: topic, messages: messages) do
-            begin
-              produce_messages(messages.map(&:phobos_message))
-            rescue Kafka::BufferOverflow, Kafka::MessageSizeTooLarge, Kafka::RecordListTooLarge
-              messages.each(&:delete)
-              raise
-            end
-          end
-          messages.first.class.where(id: messages.map(&:id)).delete_all
-          break if messages.size < BATCH_SIZE
+        loop { break unless process_topic_batch }
 
-          KafkaTopicInfo.heartbeat(@current_topic, @id) # keep alive
-          send_pending_metrics
-          messages = retrieve_messages
-        end
         KafkaTopicInfo.clear_lock(@current_topic, @id)
       rescue StandardError => e
         @logger.error("Error processing messages for topic #{@current_topic}: #{e.class.name}: #{e.message} #{e.backtrace.join("\n")}")
         KafkaTopicInfo.register_error(@current_topic, @id)
       end
 
+      # Process a single batch in a topic.
+      def process_topic_batch
+        messages = retrieve_messages
+        return false if messages.empty?
+
+        batch_size = messages.size
+        compacted_messages = compact_messages(messages)
+        log_messages(compacted_messages)
+        Deimos.instrument('db_producer.produce', topic: @current_topic, messages: compacted_messages) do
+          begin
+            produce_messages(compacted_messages.map(&:phobos_message))
+          rescue Kafka::BufferOverflow, Kafka::MessageSizeTooLarge, Kafka::RecordListTooLarge
+            Deimos::KafkaMessage.where(id: messages.map(&:id)).delete_all
+            @logger.error('Message batch too large, deleting...')
+            @logger.error(Deimos::KafkaMessage.decoded(messages))
+            raise
+          end
+        end
+        Deimos::KafkaMessage.where(id: messages.map(&:id)).delete_all
+        return false if batch_size < BATCH_SIZE
+
+        KafkaTopicInfo.heartbeat(@current_topic, @id) # keep alive
+        send_pending_metrics
+        true
+      end
+
       # @return [Array<Deimos::KafkaMessage>]
       def retrieve_messages
         KafkaMessage.where(topic: @current_topic).order(:id).limit(BATCH_SIZE)
+      end
+
+      # @param messages [Array<Deimos::KafkaMessage>]
+      def log_messages(messages)
+        return if config.log_topics != :all && !config.log_topics.include?(@current_topic)
+
+        @logger.debug do
+          decoded_messages = Deimos::KafkaMessage.decoded(messages)
+          "DB producer: Topic #{@current_topic} Producing messages: #{decoded_messages}}"
+        end
       end
 
       # Send metrics to Datadog.
@@ -139,6 +161,18 @@ module Deimos
           shutdown_producer
           retry
         end
+      end
+
+      # @param batch [Array<Deimos::KafkaMessage>]
+      # @return [Array<Deimos::KafkaMessage>]
+      def compact_messages(batch)
+        return batch unless batch.first&.key.present?
+
+        topic = batch.first.topic
+        return batch if config.compact_topics != :all &&
+                        !config.compact_topics.include?(topic)
+
+        batch.reverse.uniq!(&:key).reverse!
       end
     end
   end

--- a/spec/deimos_spec.rb
+++ b/spec/deimos_spec.rb
@@ -84,7 +84,7 @@ describe Deimos do
       allow(described_class).to receive(:run_db_backend)
     end
 
-    it 'should start if backend is db and num_producer_threads is > 0' do
+    it 'should start if backend is db and thread_count is > 0' do
       signal_handler = instance_double(Deimos::Utils::SignalHandler)
       allow(signal_handler).to receive(:run!)
       expect(Deimos::Utils::Executor).to receive(:new).
@@ -108,7 +108,7 @@ describe Deimos do
         to raise_error('Publish backend is not set to :db, exiting')
     end
 
-    it 'should not start if num_producer_threads is nil' do
+    it 'should not start if thread_count is nil' do
       expect(Deimos::Utils::SignalHandler).not_to receive(:new)
       described_class.configure do |config|
         config.publish_backend = :db
@@ -117,7 +117,7 @@ describe Deimos do
         to raise_error('Thread count is not given or set to zero, exiting')
     end
 
-    it 'should not start if num_producer_threads is 0' do
+    it 'should not start if thread_count is 0' do
       expect(Deimos::Utils::SignalHandler).not_to receive(:new)
       described_class.configure do |config|
         config.publish_backend = :db

--- a/spec/utils/db_producer_spec.rb
+++ b/spec/utils/db_producer_spec.rb
@@ -93,6 +93,67 @@ each_db_config(Deimos::Utils::DbProducer) do
       expect(phobos_producer).to have_received(:publish_list).with(['A']).once
 
     end
+
+    describe '#compact_messages' do
+      let(:batch) do
+        [
+          {
+            key: 1,
+            topic: 'my-topic',
+            message: 'AAA'
+          },
+          {
+            key: 2,
+            topic: 'my-topic',
+            message: 'BBB'
+          },
+          {
+            key: 1,
+            topic: 'my-topic',
+            message: 'CCC'
+          }
+        ].map { |h| Deimos::KafkaMessage.create!(h) }
+      end
+
+      let(:deduped_batch) { batch[1..2] }
+
+      it 'should dedupe messages when :all is set' do
+        Deimos.configure { |c| c.db_producer.compact_topics = :all }
+        expect(producer.compact_messages(batch)).to eq(deduped_batch)
+        Deimos.configure { |c| c.db_producer.compact_topics = [] }
+      end
+
+      it 'should dedupe messages when topic is included' do
+        Deimos.configure { |c| c.db_producer.compact_topics = %w(my-topic my-topic2) }
+        expect(producer.compact_messages(batch)).to eq(deduped_batch)
+        Deimos.configure { |c| c.db_producer.compact_topics = [] }
+      end
+
+      it 'should not dedupe messages when topic is not included' do
+        Deimos.configure { |c| c.db_producer.compact_topics = %w(my-topic3 my-topic2) }
+        expect(producer.compact_messages(batch)).to eq(batch)
+        Deimos.configure { |c| c.db_producer.compact_topics = [] }
+      end
+
+      it 'should not dedupe messages without keys' do
+        unkeyed_batch = [
+          {
+            key: nil,
+            topic: 'my-topic',
+            message: 'AAA'
+          },
+          {
+            key: nil,
+            topic: 'my-topic',
+            message: 'BBB'
+          }
+        ].map { |h| Deimos::KafkaMessage.create!(h) }
+        Deimos.configure { |c| c.db_producer.compact_topics = :all }
+        expect(producer.compact_messages(unkeyed_batch)).to eq(unkeyed_batch)
+        Deimos.configure { |c| c.db_producer.compact_topics = [] }
+      end
+
+    end
   end
 
   describe '#process_topic' do
@@ -193,10 +254,33 @@ each_db_config(Deimos::Utils::DbProducer) do
       expect(Deimos::KafkaTopicInfo).to receive(:register_error)
 
       expect(Deimos::KafkaMessage.count).to eq(4)
-      Deimos.subscribe('db_producer.produce') do |event|
+      subscriber = Deimos.subscribe('db_producer.produce') do |event|
         expect(event.payload[:exception_object].message).to eq('OH NOES')
         expect(event.payload[:messages]).to eq(messages)
       end
+      producer.process_topic('my-topic')
+      # don't delete for regular errors
+      expect(Deimos::KafkaMessage.count).to eq(4)
+      Deimos.unsubscribe(subscriber)
+    end
+
+    it 'should delete messages on buffer overflow' do
+      messages = (1..4).map do |i|
+        Deimos::KafkaMessage.create!(
+          id: i,
+          topic: 'my-topic',
+          message: "mess#{i}",
+          partition_key: "key#{i}"
+        )
+      end
+
+      expect(Deimos::KafkaTopicInfo).to receive(:lock).
+        with('my-topic', 'abc').and_return(true)
+      expect(producer).to receive(:produce_messages).and_raise(Kafka::BufferOverflow)
+      expect(producer).to receive(:retrieve_messages).and_return(messages)
+      expect(Deimos::KafkaTopicInfo).to receive(:register_error)
+
+      expect(Deimos::KafkaMessage.count).to eq(4)
       producer.process_topic('my-topic')
       expect(Deimos::KafkaMessage.count).to eq(0)
     end


### PR DESCRIPTION
- Added config to log messages in the DB producer.
- Added config to provide a separate logger to the DB producer.

# Pull Request Template

## Description

This adds a feature to allow the DB producer to dedupe (compact) messages in a single batch. This is based on the finding that often in Rails we will update objects multiple times, which KafkaSource will translate into multiple messages. This can cut down the number of messages actually sent by a significant amount.

This also adds the ability to log messages per topic or globally.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Primarily locally for now - want to release a beta version to test in production.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules