### PR TITLE
- Changed `pending_db_messages_max_wait` metric to send per topic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Changed `pending_db_messages_max_wait` metric to send per topic.
+
 # [1.1.0-beta1] - 2019-09-10
 - Added BatchConsumer.
 

--- a/README.md
+++ b/README.md
@@ -636,7 +636,9 @@ The following metrics are reported:
   to publish. Tagged with `topic:{topic_name}`
 * `pending_db_messages_max_wait` - the number of seconds which the
   oldest KafkaMessage in the database has been waiting for, for use
-  with the database backend.
+  with the database backend. Tagged with the topic that is waiting.
+  Will send a value of 0 with no topics tagged if there are no messages
+  waiting.
 
 ### Configuring Metrics Providers
 

--- a/lib/deimos/utils/db_producer.rb
+++ b/lib/deimos/utils/db_producer.rb
@@ -95,9 +95,20 @@ module Deimos
 
       # Send metrics to Datadog.
       def send_pending_metrics
-        first_message = KafkaMessage.first
-        time_diff = first_message ? Time.zone.now - KafkaMessage.first.created_at : 0
-        Deimos.config.metrics&.gauge('pending_db_messages_max_wait', time_diff)
+        metrics = Deimos.config.metrics
+        return unless metrics
+
+        messages = Deimos::KafkaMessage.
+          select('count(*) as num_messages, min(created_at) as earliest, topic').
+          group(:topic)
+        if messages.none?
+          metrics.gauge('pending_db_messages_max_wait', 0)
+        end
+        messages.each do |record|
+          time_diff = Time.zone.now - record.earliest
+          metrics.gauge('pending_db_messages_max_wait', time_diff,
+                        tags: ["topic:#{record.topic}"])
+        end
       end
 
       # Shut down the sync producer if we have to. Phobos will automatically


### PR DESCRIPTION
This will allow us to e.g. ignore alerts if it's on a known topic that isn't time-sensitive, or limit alerts only to a topic which is.