### PR TITLE
- Fixed bug where ActiveRecordConsumer was not using `unscoped` to up…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Fixed bug where ActiveRecordConsumer was not using `unscoped` to update
+  via primary key and causing duplicate record errors.
+
 # [1.1.0-beta1] - 2019-09-10
 - Added BatchConsumer.
 

--- a/lib/deimos/active_record_consumer.rb
+++ b/lib/deimos/active_record_consumer.rb
@@ -17,7 +17,7 @@ module Deimos
     def consume(payload, metadata)
       key = metadata.with_indifferent_access[:key]
       klass = self.class.config[:record_class]
-      record = klass.where(klass.primary_key => key).first
+      record = klass.unscoped.where(klass.primary_key => key).first
       if payload.nil?
         destroy_record(record)
         return

--- a/spec/active_record_consumer_spec.rb
+++ b/spec/active_record_consumer_spec.rb
@@ -17,6 +17,7 @@ module ActiveRecordProducerTest
 
       # :nodoc:
       class Widget < ActiveRecord::Base
+        default_scope -> { where(some_bool: false) }
       end
       Widget.reset_column_information
     end
@@ -55,7 +56,11 @@ module ActiveRecordProducerTest
         expect(widget.test_id).to eq('abc')
         expect(widget.some_int).to eq(3)
         expect(widget.some_datetime_int).to eq(Time.zone.now)
+        expect(widget.some_bool).to eq(false)
         expect(widget.updated_at).to eq(Time.zone.now)
+
+        # test unscoped
+        widget.update_attribute(:some_bool, true)
 
         # test update
         test_consume_message(MyConsumer, {
@@ -64,7 +69,8 @@ module ActiveRecordProducerTest
                                some_datetime_int: Time.zone.now.to_i,
                                timestamp: 2.minutes.ago.to_s
                              }, { call_original: true, key: 5 })
-        widget = Widget.last
+        expect(Widget.unscoped.count).to eq(1)
+        widget = Widget.unscoped.last
         expect(widget.id).to eq(5)
         expect(widget.test_id).to eq('abcd')
         expect(widget.some_int).to eq(3)


### PR DESCRIPTION
…date via primary key and causing duplicate record errors.