### PR TITLE
Change KafkaSource destroy callback to immediately publish instead of using send_events

### DIFF
--- a/lib/deimos/kafka_source.rb
+++ b/lib/deimos/kafka_source.rb
@@ -41,7 +41,7 @@ module Deimos
     def send_kafka_event_on_destroy
       return unless self.class.kafka_config[:delete]
 
-      self.class.kafka_producers.each { |p| p.send_event(self.deletion_payload) }
+      self.class.kafka_producers.each { |p| p.publish_list([self.deletion_payload]) }
     end
 
     # Payload to send after we are destroyed.

--- a/spec/kafka_source_spec.rb
+++ b/spec/kafka_source_spec.rb
@@ -89,6 +89,14 @@ module KafkaSourceSpec
       expect('my-topic-the-second').to have_sent(nil, 1)
     end
 
+    it 'should not call generate_payload but still publish a nil payload for deletion' do
+      widget = Widget.create!(widget_id: '808', name: 'delete_me!')
+      expect(Deimos::ActiveRecordProducer).not_to receive(:generate_payload)
+      widget.destroy
+      expect('my-topic').to have_sent(nil, widget.id)
+      expect('my-topic-the-second').to have_sent(nil, widget.id)
+    end
+
     it 'should send events on import' do
       widgets = (1..3).map do |i|
         Widget.new(widget_id: i, name: "Widget #{i}")


### PR DESCRIPTION
## Description

Just a quick change so that KafkaSource destroy callback skips the send_event workflow, as its not required for a simple "delete" payload

Fixes #39 

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran the RSpecs, [kafka_source_spec.rb](https://github.com/flipp-oss/deimos/blob/master/spec/kafka_source_spec.rb#L87) covers the case where `.destroy` on an ActiveRecord object should result in a nil payload published to the topic

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
