### PR TITLE
Add test backend for Deimos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Add `:test` producer backend which replaces the existing TestHelpers
+  functionality of writing messages to an in-memory hash.
+
 # [1.4.0-beta7] - 2019-12-16
 - Clone loggers when assigning to multiple levels.
 

--- a/lib/deimos.rb
+++ b/lib/deimos.rb
@@ -18,6 +18,7 @@ require 'deimos/utils/lag_reporter'
 require 'deimos/publish_backend'
 require 'deimos/backends/kafka'
 require 'deimos/backends/kafka_async'
+require 'deimos/backends/test'
 
 require 'deimos/monkey_patches/ruby_kafka_heartbeat'
 require 'deimos/monkey_patches/schema_store'

--- a/lib/deimos/backends/test.rb
+++ b/lib/deimos/backends/test.rb
@@ -1,0 +1,18 @@
+module Deimos
+  module Backends
+    # Backend which saves messages to an in-memory hash.
+    class Test < Deimos::PublishBackend
+
+      class << self
+        def sent_messages
+          @sent_messages ||= []
+        end
+      end
+
+      # @override
+      def self.execute(producer_class:, messages:)
+        self.sent_messages.concat(messages.map(&:to_h))
+      end
+    end
+  end
+end

--- a/lib/deimos/backends/test.rb
+++ b/lib/deimos/backends/test.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Deimos
   module Backends
     # Backend which saves messages to an in-memory hash.
     class Test < Deimos::PublishBackend
-
       class << self
+        # @return [Array<Hash>]
         def sent_messages
           @sent_messages ||= []
         end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -69,7 +69,7 @@ module ProducerTest
 
     it 'should produce a message' do
       expect(described_class).to receive(:produce_batch).once.with(
-        Deimos::Backends::KafkaAsync,
+        Deimos::Backends::Test,
         [
           Deimos::Message.new({ 'test_id' => 'foo', 'some_int' => 123 },
                               MyProducer,
@@ -82,7 +82,7 @@ module ProducerTest
                               partition_key: 'bar',
                               key: 'bar')
         ]
-      )
+      ).and_call_original
 
       MyProducer.publish_list(
         [{ 'test_id' => 'foo', 'some_int' => 123 },
@@ -364,6 +364,10 @@ module ProducerTest
     end
 
     describe '#determine_backend_class' do
+      before(:each) do
+        Deimos.configure { |c| c.producers.backend = :kafka_async }
+      end
+
       it 'should return kafka_async if sync is false' do
         expect(described_class.determine_backend_class(false, false)).
           to eq(Deimos::Backends::KafkaAsync)


### PR DESCRIPTION
Add `:test` producer backend which replaces the existing TestHelpers functionality of writing messages to an in-memory hash.