### PR TITLE
CCAP-59: Added session_id for KafkaMessage batches in db_producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,63 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
-# [1.6.0] - 2020-01-30
+## [1.6.0] - 2020-01-30
+
 - Added a session_id column (string) to the kafka_messages table.
 - Added an index for this session_id column.
 - DB Producer now updates the session_id column with a UUID when a batch of KafkaMessages
   is retrieved, and uses this UUID when the messages are deleted.
 
-# [1.5.0-beta2] - 2020-01-17
+## RELEASED
+
+## [1.5.0-beta2] - 2020-01-17
+
 - Added schema backends, which should simplify Avro encoding and make it
   more flexible for unit tests and local development.
 - Add `:test` producer backend which replaces the existing TestHelpers
   functionality of writing messages to an in-memory hash.
 
-# [1.4.0-beta7] - 2019-12-16
+## [1.4.0-beta7] - 2019-12-16
+
 - Clone loggers when assigning to multiple levels.
 
-# [1.4.0-beta6] - 2019-12-16
+## [1.4.0-beta6] - 2019-12-16
+
 - Added default for max_bytes_per_partition.
 
-# [1.4.0-beta4] - 2019-11-26
+## [1.4.0-beta4] - 2019-11-26
+
 - Added `define_settings` to define settings without invoking callbacks.
 
-# [1.4.0-beta2] - 2019-11-22
+## [1.4.0-beta2] - 2019-11-22
 - FIX: settings with default_proc were being called immediately
   instead of being lazy-evaluated.
 
-# [1.4.0-beta1] - 2019-11-22
+## [1.4.0-beta1] - 2019-11-22
 - Complete revamp of configuration method.
 
-# [1.3.0-beta5] - 2020-01-14
+## [1.3.0-beta5] - 2020-01-14
 - Added `db_producer.insert` and `db_producer.process` metrics.
 
-# [1.3.0-beta4] - 2019-12-02
+## [1.3.0-beta4] - 2019-12-02
 - Fixed bug where by running `rake deimos:start` without
   specifying a producer backend would crash.
 
-# [1.3.0-beta3] - 2019-11-26
+## [1.3.0-beta3] - 2019-11-26
 - Fixed bug in TestHelpers where key_decoder was not stubbed out.
 
-# [1.3.0-beta2] - 2019-11-22
+## [1.3.0-beta2] - 2019-11-22
 - Fixed bug where consumers would require a key config in all cases
   even though it's optional if they don't use keys.
 
-# [1.3.0-beta1] - 2019-11-21
+## [1.3.0-beta1] - 2019-11-21
 - Added `fetch_record` and `assign_key` methods to ActiveRecordConsumer.
 
-# [1.2.0-beta1] - 2019-09-12
+## [1.2.0-beta1] - 2019-09-12
 - Added `fatal_error` to both global config and consumer classes.
 - Changed `pending_db_messages_max_wait` metric to send per topic.
 - Added config to compact messages in the DB producer.
 - Added config to log messages in the DB producer.
 - Added config to provide a separate logger to the DB producer.
 
-# [1.1.0-beta2] - 2019-09-11
+## [1.1.0-beta2] - 2019-09-11
 - Fixed bug where ActiveRecordConsumer was not using `unscoped` to update
   via primary key and causing duplicate record errors.
 
-# [1.1.0-beta1] - 2019-09-10
+## [1.1.0-beta1] - 2019-09-10
 - Added BatchConsumer.
 
 ## [1.0.0] - 2019-09-03
@@ -114,3 +121,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-beta15] - 2019-07-08
 - Initial release.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+# [1.6.0] - 2020-01-30
+- Added a session_id column (string) to the kafka_messages table.
+- Added an index for this session_id column.
+- DB Producer now updates the session_id column with a UUID when a batch of KafkaMessages
+  is retrieved, and uses this UUID when the messages are deleted.
+
 # [1.5.0-beta2] - 2020-01-17
 - Added schema backends, which should simplify Avro encoding and make it
   more flexible for unit tests and local development.

--- a/docs/DATABASE_BACKEND.md
+++ b/docs/DATABASE_BACKEND.md
@@ -114,8 +114,8 @@ The algorithm for sending the messages makes use of the `kafka_topic_info` table
       ```
      * If the lock was unsuccessful, move on to the next topic in the list
   * Find the first 1000 messages in `kafka_messages` for that topic, ordered by ID (insertion order)
-  * Send the messages synchronously to Kafka, with all brokers acking the message.
-  * Delete the records from the DB
+  * Send the messages synchronously to Kafka, updating the `session_id` column of this batch of KafkaMessages with a unique UUID, with all brokers acking the message.
+  * Delete the records from the DB that have the same UUID of the previous step.
   * Update the `locked_at` timestamp in `kafka_topic_info` to `NOW()` to ensure liveness in case a particular batch took longer than expected to send.
   * If the current batch is 1000 messages, repeat with the next batch of
     messages until it returns less than 1000

--- a/docs/DATABASE_BACKEND.md
+++ b/docs/DATABASE_BACKEND.md
@@ -113,9 +113,10 @@ The algorithm for sending the messages makes use of the `kafka_topic_info` table
             LIMIT 1
       ```
      * If the lock was unsuccessful, move on to the next topic in the list
-  * Find the first 1000 messages in `kafka_messages` for that topic, ordered by ID (insertion order)
-  * Send the messages synchronously to Kafka, updating the `session_id` column of this batch of KafkaMessages with a unique UUID, with all brokers acking the message.
-  * Delete the records from the DB that have the same UUID of the previous step.
+  * Find the first 1000 messages in `kafka_messages` for that topic, ordered by ID (insertion order).
+  * Created a unique UUID for this batch of messages, and update the `session_id` column for this batch of messages using the UUID.
+  * Send the messages synchronously to Kafka with all brokers acking the message.
+  * Delete the KafkaMessage records from the DB utilizing the uniquely created UUID.
   * Update the `locked_at` timestamp in `kafka_topic_info` to `NOW()` to ensure liveness in case a particular batch took longer than expected to send.
   * If the current batch is 1000 messages, repeat with the next batch of
     messages until it returns less than 1000

--- a/lib/deimos/utils/db_producer.rb
+++ b/lib/deimos/utils/db_producer.rb
@@ -80,9 +80,9 @@ module Deimos
         return false if messages.empty?
 
         # Update session_id column for this batch of KafkaMessages
-        @batch_uuid = SecureRandom.uuid
+        batch_uuid = SecureRandom.uuid
         messages.update_all(
-          session_id: @batch_uuid
+          session_id: batch_uuid
         )
 
         batch_size = messages.size
@@ -92,13 +92,13 @@ module Deimos
           begin
             produce_messages(compacted_messages.map(&:phobos_message))
           rescue Kafka::BufferOverflow, Kafka::MessageSizeTooLarge, Kafka::RecordListTooLarge
-            Deimos::KafkaMessage.where(session_id: @batch_uuid).delete_all
+            Deimos::KafkaMessage.where(session_id: batch_uuid).delete_all
             @logger.error('Message batch too large, deleting...')
             @logger.error(Deimos::KafkaMessage.decoded(messages))
             raise
           end
         end
-        Deimos::KafkaMessage.where(session_id: @batch_uuid).delete_all
+        Deimos::KafkaMessage.where(session_id: batch_uuid).delete_all
         Deimos.config.metrics&.increment(
           'db_producer.process',
           tags: %W(topic:#{@current_topic}),

--- a/lib/generators/deimos/db_backend/templates/migration
+++ b/lib/generators/deimos/db_backend/templates/migration
@@ -6,9 +6,11 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.binary :key
       t.string :partition_key
       t.timestamps
+      t.string :session_id, null: false, default: '0'
     end
 
     add_index :kafka_messages, [:topic, :id]
+    add_index :kafka_messages, :session_id
 
     create_table :kafka_topic_info, force: true do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.string :topic, null: false

--- a/lib/generators/deimos/db_backend/templates/rails3_migration
+++ b/lib/generators/deimos/db_backend/templates/rails3_migration
@@ -6,9 +6,11 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.binary :key
       t.string :partition_key
       t.timestamps
+      t.string :session_id, null: false, default: '0'
     end
 
     add_index :kafka_messages, [:topic, :id]
+    add_index :kafka_messages, :session_id
 
     create_table :kafka_topic_info, force: true do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.string :topic, null: false


### PR DESCRIPTION
Created migration to add an (indexed) session_id to the kafka_messages table
Updated db_producer logic to update the session_id when a batch of messages are received (this session_id is used in the DELETES)
Updated .md files (version breaking change)