### PR TITLE
GUILD-131: Do not crash if some records exist upon import with 'on_duplicate_key_update'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
+### Fixes :wrench:
+- Fixes bug in `KafkaSource` that crashes when importing a mix of existing and new records with the `:on_duplicate_key_update` option.
 
 ## [1.6.1] - 2020-04-20
 ### Fixes :wrench:

--- a/lib/deimos/kafka_source.rb
+++ b/lib/deimos/kafka_source.rb
@@ -105,7 +105,7 @@ module Deimos
           if options[:on_duplicate_key_update].present? &&
               options[:on_duplicate_key_update] != [:updated_at]
             unique_columns = column_names.map(&:to_s) -
-                options[:on_duplicate_key_update].map(&:to_s) - %w(created_at)
+                options[:on_duplicate_key_update].map(&:to_s) - %w(id created_at)
             records = hashes_without_id.map do |hash|
               self.where(unique_columns.map { |c| [c, hash[c]] }.to_h).first
             end

--- a/lib/deimos/kafka_source.rb
+++ b/lib/deimos/kafka_source.rb
@@ -93,31 +93,37 @@ module Deimos
 
         # This will contain an array of hashes, where each hash is the actual
         # attribute hash that created the object.
-        ids = if results.is_a?(Array)
-                results[1]
-              elsif results.respond_to?(:ids)
-                results.ids
-              else
-                []
-              end
-        if ids.blank?
-          # re-fill IDs based on what was just entered into the DB.
-          if self.connection.adapter_name.downcase =~ /sqlite/
-            last_id = self.connection.select_value('select last_insert_rowid()')
-            ids = ((last_id - array_of_attributes.size + 1)..last_id).to_a
-          else # mysql
-            last_id = self.connection.select_value('select LAST_INSERT_ID()')
-            ids = (last_id..(last_id + array_of_attributes.size)).to_a
+        array_of_hashes = []
+        array_of_attributes.each do |array|
+          array_of_hashes << column_names.zip(array).to_h.with_indifferent_access
+        end
+        hashes_with_id, hashes_without_id = array_of_hashes.partition { |arr| arr[:id].present? }
+
+        self.kafka_producers.each { |p| p.send_events(hashes_with_id) }
+
+        if hashes_without_id.any?
+          if options[:on_duplicate_key_update].present? &&
+              options[:on_duplicate_key_update] != [:updated_at]
+            unique_columns = column_names.map(&:to_s) -
+                options[:on_duplicate_key_update].map(&:to_s) - %w(created_at)
+            records = hashes_without_id.map do |hash|
+              self.where(unique_columns.map { |c| [c, hash[c]] }.to_h).first
+            end
+            self.kafka_producers.each { |p| p.send_events(records) }
+          else
+            # re-fill IDs based on what was just entered into the DB.
+            if self.connection.adapter_name.downcase =~ /sqlite/
+              last_id = self.connection.select_value('select last_insert_rowid()') -
+                  hashes_without_id.size + 1
+            else # mysql
+              last_id = self.connection.select_value('select LAST_INSERT_ID()')
+            end
+            hashes_without_id.each_with_index do |attrs, i|
+              attrs[:id] = last_id + i
+            end
+            self.kafka_producers.each { |p| p.send_events(hashes_without_id) }
           end
         end
-        array_of_hashes = []
-        array_of_attributes.each_with_index do |array, i|
-          hash = column_names.zip(array).to_h.with_indifferent_access
-          hash[self.primary_key] = ids[i] if hash[self.primary_key].blank?
-          array_of_hashes << hash
-        end
-
-        self.kafka_producers.each { |p| p.send_events(array_of_hashes) }
         results
       end
     end

--- a/spec/kafka_source_spec.rb
+++ b/spec/kafka_source_spec.rb
@@ -127,8 +127,8 @@ module KafkaSourceSpec
     end
 
     it 'should send events on import with on_duplicate_key_update and existing records' do
-      widget1 = Widget.create!(widget_id: 1, name: 'Widget 1')
-      widget2 = Widget.create!(widget_id: 2, name: 'Widget 2')
+      widget1 = Widget.create(widget_id: 1, name: 'Widget 1')
+      widget2 = Widget.create(widget_id: 2, name: 'Widget 2')
       widget1.name = 'New Widget 1'
       widget2.name = 'New Widget 2'
       Widget.import([widget1, widget2], :on_duplicate_key_update => %i(widget_id name))
@@ -150,27 +150,33 @@ module KafkaSourceSpec
     end
 
     it 'should not fail when mixing existing and new records for import :on_duplicate_key_update' do
-      widget1 = Widget.new(widget_id: 1, name: 'Widget 1')
-      widget2 = Widget.new(widget_id: 2, name: 'Widget 2')
-      widget1.save
-      widget1.name = 'New Widget 1'
-      widget2.name = 'New Widget 2'
-      Widget.import([widget1, widget2], :on_duplicate_key_update => %i(widget_id name))
-
+      widget1 = Widget.create(widget_id: 1, name: 'Widget 1')
       expect('my-topic').to have_sent({
-                                          widget_id: 1,
-                                          name: 'New Widget 1',
-                                          id: widget1.id,
-                                          created_at: anything,
-                                          updated_at: anything
+                                        widget_id: 1,
+                                        name: 'Widget 1',
+                                        id: widget1.id,
+                                        created_at: anything,
+                                        updated_at: anything
                                       }, widget1.id)
+
+      widget2 = Widget.new(widget_id: 2, name: 'Widget 2')
+      widget1.name = 'New Widget 1'
+      Widget.import([widget1, widget2], :on_duplicate_key_update => %i(widget_id))
+      widgets = Widget.all
       expect('my-topic').to have_sent({
-                                          widget_id: 2,
-                                          name: 'New Widget 2',
-                                          id: widget2.id,
-                                          created_at: anything,
-                                          updated_at: anything
-                                      }, widget2.id)
+                                        widget_id: 1,
+                                        name: 'New Widget 1',
+                                        id: widgets[0].id,
+                                        created_at: anything,
+                                        updated_at: anything
+                                      }, widgets[0].id)
+      expect('my-topic').to have_sent({
+                                        widget_id: 2,
+                                        name: 'Widget 2',
+                                        id: widgets[1].id,
+                                        created_at: anything,
+                                        updated_at: anything
+                                      }, widgets[1].id)
     end
 
     it 'should send events even if the save fails' do

--- a/spec/kafka_source_spec.rb
+++ b/spec/kafka_source_spec.rb
@@ -131,7 +131,7 @@ module KafkaSourceSpec
       widget2 = Widget.create(widget_id: 2, name: 'Widget 2')
       widget1.name = 'New Widget 1'
       widget2.name = 'New Widget 2'
-      Widget.import([widget1, widget2], :on_duplicate_key_update => %i(widget_id name))
+      Widget.import([widget1, widget2], on_duplicate_key_update: %i(widget_id name))
 
       expect('my-topic').to have_sent({
                                         widget_id: 1,
@@ -161,7 +161,7 @@ module KafkaSourceSpec
 
       widget2 = Widget.new(widget_id: 2, name: 'Widget 2')
       widget1.name = 'New Widget 1'
-      Widget.import([widget1, widget2], :on_duplicate_key_update => %i(widget_id))
+      Widget.import([widget1, widget2], on_duplicate_key_update: %i(widget_id))
       widgets = Widget.all
       expect('my-topic').to have_sent({
                                         widget_id: 1,

--- a/spec/kafka_source_spec.rb
+++ b/spec/kafka_source_spec.rb
@@ -126,6 +126,53 @@ module KafkaSourceSpec
                                       }, widgets[2].id)
     end
 
+    it 'should send events on import with on_duplicate_key_update and existing records' do
+      widget1 = Widget.create!(widget_id: 1, name: 'Widget 1')
+      widget2 = Widget.create!(widget_id: 2, name: 'Widget 2')
+      widget1.name = 'New Widget 1'
+      widget2.name = 'New Widget 2'
+      Widget.import([widget1, widget2], :on_duplicate_key_update => %i(widget_id name))
+
+      expect('my-topic').to have_sent({
+                                        widget_id: 1,
+                                        name: 'New Widget 1',
+                                        id: widget1.id,
+                                        created_at: anything,
+                                        updated_at: anything
+                                      }, widget1.id)
+      expect('my-topic').to have_sent({
+                                        widget_id: 2,
+                                        name: 'New Widget 2',
+                                        id: widget2.id,
+                                        created_at: anything,
+                                        updated_at: anything
+                                      }, widget2.id)
+    end
+
+    it 'should not fail when mixing existing and new records for import :on_duplicate_key_update' do
+      widget1 = Widget.new(widget_id: 1, name: 'Widget 1')
+      widget2 = Widget.new(widget_id: 2, name: 'Widget 2')
+      widget1.save
+      widget1.name = 'New Widget 1'
+      widget2.name = 'New Widget 2'
+      Widget.import([widget1, widget2], :on_duplicate_key_update => %i(widget_id name))
+
+      expect('my-topic').to have_sent({
+                                          widget_id: 1,
+                                          name: 'New Widget 1',
+                                          id: widget1.id,
+                                          created_at: anything,
+                                          updated_at: anything
+                                      }, widget1.id)
+      expect('my-topic').to have_sent({
+                                          widget_id: 2,
+                                          name: 'New Widget 2',
+                                          id: widget2.id,
+                                          created_at: anything,
+                                          updated_at: anything
+                                      }, widget2.id)
+    end
+
     it 'should send events even if the save fails' do
       widget = Widget.create!(widget_id: 1, name: 'widget')
       expect('my-topic').to have_sent({


### PR DESCRIPTION
## Description

Fixes bug in `KafkaSource` that crashes if some records exist upon import with the `:on_duplicate_key_update` option

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] In rails console:
```ruby
# Same number of messages are published to kafka, with the correct content
# 1. Import still works
YourModel.import(<new_records>)

# 2. Import with :on_duplicate_key_update option
YourModel.import(<updated_records>, on_duplicate_key_update: %i(columns_to_update))

# 3. Import with :on_duplicate_key_update option and a mix of new and existing records
YourModel.import(<new_and_updated_records>, on_duplicate_key_update: %i(columns_to_update))
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
