### PR TITLE
Recalculate lag on heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
+### Fixes :wrench:
+- Lag calculation can be incorrect if no messages are being consumed.
 
 ## [1.6.1] - 2020-04-20
 ### Fixes :wrench:

--- a/lib/deimos/utils/lag_reporter.rb
+++ b/lib/deimos/utils/lag_reporter.rb
@@ -31,40 +31,19 @@ module Deimos
 
         # @param topic [String]
         # @param partition [Integer]
-        # @param lag [Integer]
-        def assign_lag(topic, partition, lag)
-          self.topics[topic.to_s] ||= Topic.new(topic, self)
-          self.topics[topic.to_s].assign_lag(partition, lag)
-        end
-
-        # Figure out the current lag by asking Kafka based on the current offset.
-        # @param topic [String]
-        # @param partition [Integer]
         # @param offset [Integer]
-        def compute_lag(topic, partition, offset)
+        def assign_current_offset(topic, partition, offset)
           self.topics[topic.to_s] ||= Topic.new(topic, self)
-          self.topics[topic.to_s].compute_lag(partition, offset)
-        end
-
-        # Adjust the current lag based by asking Kafka based on the current offset.
-        # @param topic [String]
-        # @param partition [Integer]
-        # @param offset [Integer]
-        def recompute_lag(topic, partition)
-          self.topics[topic.to_s] ||= Topic.new(topic, self)
-          self.topics[topic.to_s].recompute_lag(partition)
+          self.topics[topic.to_s].assign_current_offset(partition, offset)
         end
       end
 
-      # Topic which has a hash of partition => last known offset lag and
-      # hash of partition => last known offset
+      # Topic which has a hash of partition => last known current offsets
       class Topic
         # @return [String]
         attr_accessor :topic_name
         # @return [Hash<Integer, Integer>]
-        attr_accessor :partition_offset_lags
-        # @return [Hash<Integer, Integer>]
-        attr_accessor :partition_last_offsets
+        attr_accessor :partition_current_offsets
         # @return [ConsumerGroup]
         attr_accessor :consumer_group
 
@@ -73,62 +52,33 @@ module Deimos
         def initialize(topic_name, group)
           self.topic_name = topic_name
           self.consumer_group = group
-          self.partition_offset_lags = {}
-          self.partition_last_offsets = {}
+          self.partition_current_offsets = {}
         end
 
         # @param partition [Integer]
-        # @param lag [Integer]
-        def assign_lag(partition, lag)
-          self.partition_offset_lags[partition.to_i] = lag
+        def assign_current_offset(partition, offset)
+          self.partition_current_offsets[partition.to_i] = offset
         end
 
         # @param partition [Integer]
-        # @param lag [Integer]
-        def assign_last_offset(partition, offset)
-          self.partition_last_offsets[partition.to_i] = offset
-        end
-
-        # @param partition [Integer]
-        # @param offset [Integer]
         def compute_lag(partition, offset)
-          return if self.partition_offset_lags[partition.to_i]
-
           begin
             client = Phobos.create_kafka_client
             last_offset = client.last_offset_for(self.topic_name, partition)
-            # Store this "last offset" for later
-            assign_last_offset(partition, last_offset)
-            assign_lag(partition, [last_offset - offset, 0].max)
+            lag = last_offset - offset
           rescue StandardError # don't do anything, just wait
             Deimos.config.logger.
               debug("Error computing lag for #{self.topic_name}, will retry")
           end
-        end
-
-        # @param partition [Integer]
-        # @param offset [Integer]
-        def recompute_lag(partition)
-          current_lag = self.partition_offset_lags[partition.to_i]
-          last_reported_offset = self.partition_last_offsets[partition.to_i]
-          return unless current_lag && last_reported_offset
-
-          begin
-            client = Phobos.create_kafka_client
-            last_offset = client.last_offset_for(self.topic_name, partition)
-            assign_last_offset(partition, last_offset)
-            assign_lag(partition, current_lag + (last_offset - last_reported_offset))
-          rescue StandardError # don't do anything, just wait
-            Deimos.config.logger.
-              debug("Error recomputing lag for #{self.topic_name}, will retry")
-          end
+          lag || 0
         end
 
         # @param partition [Integer]
         def report_lag(partition)
-          lag = self.partition_offset_lags[partition.to_i]
-          return unless lag
+          current_offset = self.partition_current_offsets[partition.to_i]
+          return unless current_offset
 
+          lag = compute_lag(partition, current_offset)
           group = self.consumer_group.id
           Deimos.config.logger.
             debug("Sending lag: #{group}/#{partition}: #{lag}")
@@ -148,16 +98,20 @@ module Deimos
           @groups = {}
         end
 
+        # offset_lag = event.payload.fetch(:offset_lag)
+        # group_id = event.payload.fetch(:group_id)
+        # topic = event.payload.fetch(:topic)
+        # partition = event.payload.fetch(:partition)
         # @param payload [Hash]
         def message_processed(payload)
-          lag = payload[:offset_lag]
+          offset = payload[:offset] || payload[:last_offset]
           topic = payload[:topic]
           group = payload[:group_id]
           partition = payload[:partition]
 
           synchronize do
             @groups[group.to_s] ||= ConsumerGroup.new(group)
-            @groups[group.to_s].assign_lag(topic, partition, lag)
+            @groups[group.to_s].assign_current_offset(topic, partition, offset)
           end
         end
 
@@ -170,7 +124,7 @@ module Deimos
 
           synchronize do
             @groups[group.to_s] ||= ConsumerGroup.new(group)
-            @groups[group.to_s].compute_lag(topic, partition, offset)
+            @groups[group.to_s].assign_current_offset(topic, partition, offset)
           end
         end
 
@@ -182,7 +136,6 @@ module Deimos
             consumer_group = @groups[group.to_s]
             payload[:topic_partitions].each do |topic, partitions|
               partitions.each do |partition|
-                consumer_group.recompute_lag(topic, partition)
                 consumer_group.report_lag(topic, partition)
               end
             end

--- a/spec/utils/lag_reporter_spec.rb
+++ b/spec/utils/lag_reporter_spec.rb
@@ -38,7 +38,7 @@ describe Deimos::Utils::LagReporter do
     )
     ActiveSupport::Notifications.instrument(
       'start_process_message.consumer.kafka',
-      offset_lag: 80, topic: 'my-topic', group_id: 'group1', partition: 2
+      offset: 20, topic: 'my-topic', group_id: 'group1', partition: 2
     )
     ActiveSupport::Notifications.instrument(
       'heartbeat.consumer.kafka',
@@ -46,7 +46,7 @@ describe Deimos::Utils::LagReporter do
     )
     ActiveSupport::Notifications.instrument(
       'start_process_batch.consumer.kafka',
-      offset_lag: 0, topic: 'my-topic', group_id: 'group1', partition: 2
+      last_offset: 100, topic: 'my-topic', group_id: 'group1', partition: 2
     )
     ActiveSupport::Notifications.instrument(
       'heartbeat.consumer.kafka',

--- a/spec/utils/lag_reporter_spec.rb
+++ b/spec/utils/lag_reporter_spec.rb
@@ -2,8 +2,11 @@
 
 describe Deimos::Utils::LagReporter do
 
+  let(:kafka_client) { instance_double(Kafka::Client) }
+  let(:partition1_tags) { %w(consumer_group:group1 partition:1 topic:my-topic) }
+  let(:partition2_tags) { %w(consumer_group:group1 partition:2 topic:my-topic) }
+
   before(:each) do
-    kafka_client = instance_double(Kafka::Client)
     allow(kafka_client).to receive(:last_offset_for).and_return(100)
     allow(Phobos).to receive(:create_kafka_client).and_return(kafka_client)
     Deimos.configure { |c| c.consumers.report_lag = true }
@@ -20,31 +23,15 @@ describe Deimos::Utils::LagReporter do
       'heartbeat.consumer.kafka',
       group_id: 'group1', topic_partitions: { 'my-topic': [1] }
     )
-
   end
 
   it 'should report lag' do
     expect(Deimos.config.metrics).to receive(:gauge).ordered.twice.
-      with('consumer_lag', 95,
-           tags: %w(
-             consumer_group:group1
-             partition:1
-             topic:my-topic
-           ))
+      with('consumer_lag', 95, tags: partition1_tags)
     expect(Deimos.config.metrics).to receive(:gauge).ordered.once.
-      with('consumer_lag', 80,
-           tags: %w(
-             consumer_group:group1
-             partition:2
-             topic:my-topic
-           ))
+      with('consumer_lag', 80, tags: partition2_tags)
     expect(Deimos.config.metrics).to receive(:gauge).ordered.once.
-      with('consumer_lag', 0,
-           tags: %w(
-             consumer_group:group1
-             partition:2
-             topic:my-topic
-           ))
+      with('consumer_lag', 0, tags: partition2_tags)
     ActiveSupport::Notifications.instrument(
       'seek.consumer.kafka',
       offset: 5, topic: 'my-topic', group_id: 'group1', partition: 1
@@ -61,6 +48,26 @@ describe Deimos::Utils::LagReporter do
       'start_process_batch.consumer.kafka',
       offset_lag: 0, topic: 'my-topic', group_id: 'group1', partition: 2
     )
+    ActiveSupport::Notifications.instrument(
+      'heartbeat.consumer.kafka',
+      group_id: 'group1', topic_partitions: { 'my-topic': [1, 2] }
+    )
+  end
+
+  it 'should update lag after heartbeat' do
+    expect(Deimos.config.metrics).to receive(:gauge).ordered.once.
+      with('consumer_lag', 94, tags: partition2_tags)
+    expect(Deimos.config.metrics).to receive(:gauge).ordered.once.
+      with('consumer_lag', 95, tags: partition2_tags)
+    ActiveSupport::Notifications.instrument(
+      'seek.consumer.kafka',
+      offset: 6, topic: 'my-topic', group_id: 'group1', partition: 2
+    )
+    ActiveSupport::Notifications.instrument(
+      'heartbeat.consumer.kafka',
+      group_id: 'group1', topic_partitions: { 'my-topic': [1, 2] }
+    )
+    allow(kafka_client).to receive(:last_offset_for).and_return(101)
     ActiveSupport::Notifications.instrument(
       'heartbeat.consumer.kafka',
       group_id: 'group1', topic_partitions: { 'my-topic': [1, 2] }


### PR DESCRIPTION
# Pull Request Template

## Description
Fixes #4, introduces `partition_last_offsets` that is used to recalculate consumer lag on heartbeat.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] TBD - Publish messages to kafka while consumer is not consuming?
Pending dev tests, updated unit tests
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
