### PR TITLE
Update send_produce_error to decode failed_messages with built-in decoder. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ActiveRecordConsumer` batch mode
 
 ### Fixes :wrench:
+- Fixes #19 - Fixes `send_produce_error` to decode `failed_messages` with built-in decoder. 
 - Lag calculation can be incorrect if no messages are being consumed.
 - Fixed bug where printing messages on a MessageSizeTooLarge
   error didn't work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ActiveRecordConsumer` batch mode
 
 ### Fixes :wrench:
-- Fixes #19 - Fixes `send_produce_error` to decode `failed_messages` with built-in decoder. 
+- Fixes `send_produce_error` to decode `failed_messages` with built-in decoder. 
 - Lag calculation can be incorrect if no messages are being consumed.
 - Fixed bug where printing messages on a MessageSizeTooLarge
   error didn't work.

--- a/lib/deimos/instrumentation.rb
+++ b/lib/deimos/instrumentation.rb
@@ -47,7 +47,7 @@ module Deimos
       messages = exception.failed_messages
       messages.group_by(&:topic).each do |topic, batch|
         producer = Deimos::Producer.descendants.find { |c| c.topic == topic }
-        next unless batch.any? && producer
+        next if batch.empty? || !producer
 
         decoder = Deimos.schema_backend(schema: producer.config[:schema],
                                         namespace: producer.config[:namespace])

--- a/spec/kafka_listener_spec.rb
+++ b/spec/kafka_listener_spec.rb
@@ -25,7 +25,7 @@ describe Deimos::KafkaListener do
     end
   end
 
-  it 'should listen to publishing errors and republish events' do
+  it 'should listen to publishing errors and republish as Deimos events' do
     Deimos.subscribe('produce_error') do |event|
       expect(event.payload).to include(
         producer: MyProducer,

--- a/spec/kafka_listener_spec.rb
+++ b/spec/kafka_listener_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe Deimos::KafkaListener do
+  include_context 'with widgets'
+
+  prepend_before(:each) do
+    producer_class = Class.new(Deimos::Producer) do
+      schema 'MySchema'
+      namespace 'com.my-namespace'
+      topic 'my-topic'
+      key_config none: true
+    end
+    stub_const('MyProducer', producer_class)
+  end
+
+  let(:payloads) do
+    [{ 'test_id' => 'foo', 'some_int' => 123 },
+     { 'test_id' => 'bar', 'some_int' => 124 }]
+  end
+
+  before(:each) do
+    Deimos.configure do |c|
+      c.producers.backend = :kafka
+      c.schema.backend = :avro_local
+    end
+  end
+
+  it 'should listen to publishing errors and republish events' do
+    Deimos.subscribe('produce_error') do |event|
+      expect(event.payload).to include(
+        producer: MyProducer,
+        topic: 'my-topic',
+        payloads: payloads
+      )
+    end
+    allow_any_instance_of(Kafka::Cluster).to receive(:partitions_for).
+      and_raise(Kafka::Error)
+    expect(Deimos.config.metrics).to receive(:increment).
+      with('publish_error', tags: %w(topic:my-topic), by: 2)
+
+    expect { MyProducer.publish_list(payloads) }.to raise_error(Kafka::DeliveryFailed)
+  end
+end

--- a/spec/kafka_listener_spec.rb
+++ b/spec/kafka_listener_spec.rb
@@ -13,31 +13,42 @@ describe Deimos::KafkaListener do
     stub_const('MyProducer', producer_class)
   end
 
-  let(:payloads) do
-    [{ 'test_id' => 'foo', 'some_int' => 123 },
-     { 'test_id' => 'bar', 'some_int' => 124 }]
-  end
-
   before(:each) do
     Deimos.configure do |c|
       c.producers.backend = :kafka
       c.schema.backend = :avro_local
     end
-  end
-
-  it 'should listen to publishing errors and republish as Deimos events' do
-    Deimos.subscribe('produce_error') do |event|
-      expect(event.payload).to include(
-        producer: MyProducer,
-        topic: 'my-topic',
-        payloads: payloads
-      )
-    end
+    allow_any_instance_of(Kafka::Cluster).to receive(:add_target_topics)
     allow_any_instance_of(Kafka::Cluster).to receive(:partitions_for).
       and_raise(Kafka::Error)
-    expect(Deimos.config.metrics).to receive(:increment).
-      with('publish_error', tags: %w(topic:my-topic), by: 2)
+  end
 
-    expect { MyProducer.publish_list(payloads) }.to raise_error(Kafka::DeliveryFailed)
+  describe '.send_produce_error' do
+    let(:payloads) do
+      [{ 'test_id' => 'foo', 'some_int' => 123 },
+       { 'test_id' => 'bar', 'some_int' => 124 }]
+    end
+
+    it 'should listen to publishing errors and republish as Deimos events' do
+      Deimos.subscribe('produce_error') do |event|
+        expect(event.payload).to include(
+          producer: MyProducer,
+          topic: 'my-topic',
+          payloads: payloads
+        )
+      end
+      expect(Deimos.config.metrics).to receive(:increment).
+        with('publish_error', tags: %w(topic:my-topic), by: 2)
+      expect { MyProducer.publish_list(payloads) }.to raise_error(Kafka::DeliveryFailed)
+    end
+
+    it 'should not send any notifications when producer is not found' do
+      Deimos.subscribe('produce_error') do |_|
+        raise 'OH NOES'
+      end
+      allow(Deimos::Producer).to receive(:descendants).and_return([])
+      expect(Deimos.config.metrics).not_to receive(:increment).with('publish_error', anything)
+      expect { MyProducer.publish_list(payloads) }.to raise_error(Kafka::DeliveryFailed)
+    end
   end
 end


### PR DESCRIPTION
## Description

Fixes #19 - Update `send_produce_error` to decode `failed_messages` with built-in decoder. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on a staging environment of fadmin. Metrics show up in datadog tracking when errors happen during the delivery of messages to kafka. i.e 
```
Failed to send all messages to multi.Flyers.FlyerDataResponse/2; attempting retry 1 of 10 after 5s
Failed to fetch metadata from kafka://kafka-stg.bootstrap.wishabi.net:9093: Connection error Errno::ETIMEDOUT: Connection timed out
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
