### PR TITLE
Copy DB producer fixes from fadmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+### Fixes :wrench:
+- Retry deleting messages without resending the batch if the
+  delete fails (fixes [#34](https://github.com/flipp-oss/deimos/issues/34))
+- Delete messages in batches rather than all at once to
+  cut down on the chance of a deadlock.
+
+### Features :star:
+- Add `last_processed_at` to `kafka_topic_info` to ensure
+  that wait metrics are accurate in cases where records
+  get created with an old `created_at` time (e.g. for
+  long-running transactions).
+
 ## 1.8.0-beta2 - 2020-07-08
 
 ### Fixes :wrench:

--- a/lib/generators/deimos/db_backend/templates/migration
+++ b/lib/generators/deimos/db_backend/templates/migration
@@ -16,6 +16,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.datetime :locked_at
       t.boolean :error, null: false, default: false
       t.integer :retries, null: false, default: 0
+      t.datetime :last_processed_at
     end
     add_index :kafka_topic_info, :topic, unique: true
     add_index :kafka_topic_info, [:locked_by, :error]

--- a/lib/generators/deimos/db_backend/templates/rails3_migration
+++ b/lib/generators/deimos/db_backend/templates/rails3_migration
@@ -16,6 +16,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.datetime :locked_at
       t.boolean :error, null: false, default: false
       t.integer :retries, null: false, default: 0
+      t.datetime :last_processed_at
     end
     add_index :kafka_topic_info, :topic, unique: true
     add_index :kafka_topic_info, [:locked_by, :error]

--- a/spec/kafka_topic_info_spec.rb
+++ b/spec/kafka_topic_info_spec.rb
@@ -37,22 +37,45 @@ each_db_config(Deimos::KafkaTopicInfo) do
   end
 
   specify '#clear_lock' do
-    described_class.create!(topic: 'my-topic', locked_by: 'abc',
-                            locked_at: 10.seconds.ago, error: true, retries: 1)
-    described_class.create!(topic: 'my-topic2', locked_by: 'def',
-                            locked_at: 10.seconds.ago, error: true, retries: 1)
-    described_class.clear_lock('my-topic', 'abc')
-    expect(described_class.count).to eq(2)
-    record = described_class.first
-    expect(record.locked_by).to eq(nil)
-    expect(record.locked_at).to eq(nil)
-    expect(record.error).to eq(false)
-    expect(record.retries).to eq(0)
-    record = described_class.last
-    expect(record.locked_by).not_to eq(nil)
-    expect(record.locked_at).not_to eq(nil)
-    expect(record.error).not_to eq(false)
-    expect(record.retries).not_to eq(0)
+    freeze_time do
+      Deimos::KafkaTopicInfo.create!(topic: 'my-topic', locked_by: 'abc',
+                                     locked_at: 10.seconds.ago, error: true, retries: 1,
+                                     last_processed_at: 20.seconds.ago)
+      Deimos::KafkaTopicInfo.create!(topic: 'my-topic2', locked_by: 'def',
+                                     locked_at: 10.seconds.ago, error: true, retries: 1,
+                                     last_processed_at: 20.seconds.ago)
+      Deimos::KafkaTopicInfo.clear_lock('my-topic', 'abc')
+      expect(Deimos::KafkaTopicInfo.count).to eq(2)
+      record = Deimos::KafkaTopicInfo.first
+      expect(record.locked_by).to eq(nil)
+      expect(record.locked_at).to eq(nil)
+      expect(record.error).to eq(false)
+      expect(record.retries).to eq(0)
+      expect(record.last_processed_at.to_s).to eq(Time.zone.now.to_s)
+      record = Deimos::KafkaTopicInfo.last
+      expect(record.locked_by).not_to eq(nil)
+      expect(record.locked_at).not_to eq(nil)
+      expect(record.error).not_to eq(false)
+      expect(record.retries).not_to eq(0)
+      expect(record.last_processed_at.to_s).to eq(20.seconds.ago.to_s)
+    end
+  end
+
+  specify '#ping_empty_topics' do
+    freeze_time do
+      old_time = 1.hour.ago.to_s
+      t1 = Deimos::KafkaTopicInfo.create!(topic: 'topic1', last_processed_at: old_time)
+      t2 = Deimos::KafkaTopicInfo.create!(topic: 'topic2', last_processed_at: old_time)
+      t3 = Deimos::KafkaTopicInfo.create!(topic: 'topic3', last_processed_at: old_time,
+                                          locked_by: 'me', locked_at: 1.minute.ago)
+
+      expect(Deimos::KafkaTopicInfo.count).to eq(3)
+      Deimos::KafkaTopicInfo.all.each { |t| expect(t.last_processed_at.to_s).to eq(old_time) }
+      Deimos::KafkaTopicInfo.ping_empty_topics(%w(topic1))
+      expect(t1.reload.last_processed_at.to_s).to eq(old_time) # was passed as an exception
+      expect(t2.reload.last_processed_at.to_s).to eq(Time.zone.now.to_s)
+      expect(t3.reload.last_processed_at.to_s).to eq(old_time) # is locked
+    end
   end
 
   specify '#register_error' do


### PR DESCRIPTION
- Retry deleting messages without resending the batch if the delete fails (fixes #34)
- Delete messages in batches rather than all at once to cut down on the chance of a deadlock.
- Add `last_processed_at` to `kafka_topic_info` to ensure that wait metrics are accurate in cases where records get created with an old `created_at` time (e.g. for long-running transactions).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested in production with relatively heavy load and an old MySQL database.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules