### PR TITLE
GH-75: Handle batch of unique messages in compact_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+### Fixes :wrench:
+- Fix for compacting messages if all the keys are already unique
+  (fixes [#75](https://github.com/flipp-oss/deimos/issues/75))
+
 ## 1.8.1-beta6 - 2020-08-13
 - Fix for consuming nil payloads with Ruby 2.3.
 

--- a/lib/deimos/utils/db_producer.rb
+++ b/lib/deimos/utils/db_producer.rb
@@ -231,7 +231,7 @@ module Deimos
         return batch if config.compact_topics != :all &&
                         !config.compact_topics.include?(topic)
 
-        batch.reverse.uniq!(&:key).reverse!
+        batch.reverse.uniq(&:key).reverse!
       end
     end
   end

--- a/spec/utils/db_producer_spec.rb
+++ b/spec/utils/db_producer_spec.rb
@@ -155,6 +155,10 @@ each_db_config(Deimos::Utils::DbProducer) do
         Deimos.configure { |c| c.db_producer.compact_topics = [] }
       end
 
+      it 'should not raise NoMethodError if all the keys are unique' do
+        Deimos.configure { |c| c.db_producer.compact_topics = %w(my-topic my-topic2) }
+        expect{ producer.compact_messages(deduped_batch) }.to_not raise_error(NoMethodError)
+      end
     end
   end
 

--- a/spec/utils/db_producer_spec.rb
+++ b/spec/utils/db_producer_spec.rb
@@ -157,7 +157,7 @@ each_db_config(Deimos::Utils::DbProducer) do
 
       it 'should not raise NoMethodError if all the keys are unique' do
         Deimos.configure { |c| c.db_producer.compact_topics = %w(my-topic my-topic2) }
-        expect{ producer.compact_messages(deduped_batch) }.to_not raise_error(NoMethodError)
+        expect { producer.compact_messages(deduped_batch) }.not_to raise_error(NoMethodError)
       end
     end
   end

--- a/spec/utils/db_producer_spec.rb
+++ b/spec/utils/db_producer_spec.rb
@@ -155,9 +155,9 @@ each_db_config(Deimos::Utils::DbProducer) do
         Deimos.configure { |c| c.db_producer.compact_topics = [] }
       end
 
-      it 'should not raise NoMethodError if all the keys are unique' do
+      it 'should compact messages when all messages are unique' do
         Deimos.configure { |c| c.db_producer.compact_topics = %w(my-topic my-topic2) }
-        expect { producer.compact_messages(deduped_batch) }.not_to raise_error(NoMethodError)
+        expect(producer.compact_messages(deduped_batch)).to eq(deduped_batch)
       end
     end
   end


### PR DESCRIPTION
# Pull Request Template

## Description

`compact_messages` now uses `uniq` instead of `uniq!` which was causing it to fail on batch of unique messages.

Fixes #75 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Testing on local environment with Fadmin by monkey patching and using "Flyers.PageItem" topic (locally)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
