### PR TITLE
CPFM-331. Add ability to specify topic in publish and publish list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
+- Added the ability to specify the topic for `publish`
+and `publish_list` in a producer
 
 ## 1.8.1-beta9 - 2020-08-27
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ class MyProducer < Deimos::Producer
         'some-key2' => an_object.bar
       }
       # You can also publish an array with self.publish_list(payloads)
+      # You may specify the topic here with self.publish(payload, topic: 'my-topic')
       self.publish(payload)
     end
     

--- a/lib/deimos/producer.rb
+++ b/lib/deimos/producer.rb
@@ -87,8 +87,8 @@ module Deimos
 
       # Publish the payload to the topic.
       # @param payload [Hash] with an optional payload_key hash key.
-      def publish(payload)
-        publish_list([payload])
+      def publish(payload, topic: self.topic)
+        publish_list([payload], topic: topic)
       end
 
       # Publish a list of messages.
@@ -97,7 +97,7 @@ module Deimos
       # whether to publish synchronously.
       # @param force_send [Boolean] if true, ignore the configured backend
       # and send immediately to Kafka.
-      def publish_list(payloads, sync: nil, force_send: false)
+      def publish_list(payloads, sync: nil, force_send: false, topic: self.topic)
         return if Deimos.config.kafka.seed_brokers.blank? ||
                   Deimos.config.producers.disabled ||
                   Deimos.producers_disabled?(self)
@@ -110,7 +110,7 @@ module Deimos
           payloads: payloads
         ) do
           messages = Array(payloads).map { |p| Deimos::Message.new(p, self) }
-          messages.each(&method(:_process_message))
+          messages.each { |m| _process_message(m, topic) }
           messages.in_groups_of(MAX_BATCH_SIZE, false) do |batch|
             self.produce_batch(backend_class, batch)
           end
@@ -163,7 +163,7 @@ module Deimos
     private
 
       # @param message [Message]
-      def _process_message(message)
+      def _process_message(message, topic)
         # this violates the Law of Demeter but it has to happen in a very
         # specific order and requires a bunch of methods on the producer
         # to work correctly.
@@ -175,7 +175,7 @@ module Deimos
         message.payload = nil if message.payload.blank?
         message.coerce_fields(encoder)
         message.encoded_key = _encode_key(message.key)
-        message.topic = self.topic
+        message.topic = topic
         message.encoded_payload = if message.payload.nil?
                                     nil
                                   else

--- a/lib/deimos/producer.rb
+++ b/lib/deimos/producer.rb
@@ -87,6 +87,7 @@ module Deimos
 
       # Publish the payload to the topic.
       # @param payload [Hash] with an optional payload_key hash key.
+      # @param topic [String] if specifying the topic
       def publish(payload, topic: self.topic)
         publish_list([payload], topic: topic)
       end
@@ -97,6 +98,7 @@ module Deimos
       # whether to publish synchronously.
       # @param force_send [Boolean] if true, ignore the configured backend
       # and send immediately to Kafka.
+      # @param topic [String] if specifying the topic
       def publish_list(payloads, sync: nil, force_send: false, topic: self.topic)
         return if Deimos.config.kafka.seed_brokers.blank? ||
                   Deimos.config.producers.disabled ||
@@ -163,6 +165,7 @@ module Deimos
     private
 
       # @param message [Message]
+      # @param topic [String]
       def _process_message(message, topic)
         # this violates the Law of Demeter but it has to happen in a very
         # specific order and requires a bunch of methods on the producer

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -104,19 +104,19 @@ module ProducerTest
 
     it 'should allow setting the topic from publish_list' do
       expect(described_class).to receive(:produce_batch).once.with(
-          Deimos::Backends::Test,
-          [
-              Deimos::Message.new({ 'test_id' => 'foo', 'some_int' => 123 },
-                                  MyProducer,
-                                  topic: 'a-new-topic',
-                                  partition_key: 'foo',
-                                  key: 'foo'),
-              Deimos::Message.new({ 'test_id' => 'bar', 'some_int' => 124 },
-                                  MyProducer,
-                                  topic: 'a-new-topic',
-                                  partition_key: 'bar',
-                                  key: 'bar')
-          ]
+        Deimos::Backends::Test,
+        [
+          Deimos::Message.new({ 'test_id' => 'foo', 'some_int' => 123 },
+                              MyProducer,
+                              topic: 'a-new-topic',
+                              partition_key: 'foo',
+                              key: 'foo'),
+          Deimos::Message.new({ 'test_id' => 'bar', 'some_int' => 124 },
+                              MyProducer,
+                              topic: 'a-new-topic',
+                              partition_key: 'bar',
+                              key: 'bar')
+        ]
       ).and_call_original
 
       MyProducer.publish_list(

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -102,6 +102,33 @@ module ProducerTest
       expect('my-topic').not_to have_sent('test_id' => 'foo2', 'some_int' => 123)
     end
 
+    it 'should allow setting the topic from publish_list' do
+      expect(described_class).to receive(:produce_batch).once.with(
+          Deimos::Backends::Test,
+          [
+              Deimos::Message.new({ 'test_id' => 'foo', 'some_int' => 123 },
+                                  MyProducer,
+                                  topic: 'a-new-topic',
+                                  partition_key: 'foo',
+                                  key: 'foo'),
+              Deimos::Message.new({ 'test_id' => 'bar', 'some_int' => 124 },
+                                  MyProducer,
+                                  topic: 'a-new-topic',
+                                  partition_key: 'bar',
+                                  key: 'bar')
+          ]
+      ).and_call_original
+
+      MyProducer.publish_list(
+        [{ 'test_id' => 'foo', 'some_int' => 123 },
+         { 'test_id' => 'bar', 'some_int' => 124 }],
+        topic: 'a-new-topic'
+      )
+      expect('a-new-topic').to have_sent('test_id' => 'foo', 'some_int' => 123)
+      expect('my-topic').not_to have_sent('test_id' => 'foo', 'some_int' => 123)
+      expect('my-topic').not_to have_sent('test_id' => 'foo2', 'some_int' => 123)
+    end
+
     it 'should add a message ID' do
       payload = { 'test_id' => 'foo',
                   'some_int' => 123,


### PR DESCRIPTION
# Pull Request Template

## Description

This change allows for a topic to be specified in the 'publish' and 'publish_list' methods of a producer. This will override the topic set in the producer configuration for said producer. The benefit is so that you may have 1 producer that produces to multiple topics.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

No, this has not been tested outside of specs. This will be used/tested with the upcoming Workflow Execution System being built by the Content Platform team.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
