### PR TITLE
GH-50: Raise error if no topic is given while producing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+### Fixes :wrench:
+- Raise error if producing without a topic
+  (fixes [#50](https://github.com/flipp-oss/deimos/issues/50))
+
+
 ## 1.8.2-beta2 - 2020-09-15
 
 ### Features :star:

--- a/lib/deimos/producer.rb
+++ b/lib/deimos/producer.rb
@@ -104,7 +104,7 @@ module Deimos
                   Deimos.config.producers.disabled ||
                   Deimos.producers_disabled?(self)
 
-        raise 'Topic not given! Please specify the topic.' if topic.blank?
+        raise 'Topic not specified. Please specify the topic.' if topic.blank?
 
         backend_class = determine_backend_class(sync, force_send)
         Deimos.instrument(

--- a/lib/deimos/producer.rb
+++ b/lib/deimos/producer.rb
@@ -104,6 +104,8 @@ module Deimos
                   Deimos.config.producers.disabled ||
                   Deimos.producers_disabled?(self)
 
+        raise 'Topic not given! Please specify the topic.' if topic.blank?
+
         backend_class = determine_backend_class(sync, force_send)
         Deimos.instrument(
           'encode_messages',

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -307,39 +307,26 @@ module ProducerTest
     it 'should raise error if blank topic is passed in explicitly' do
       expect {
         MyProducer.publish_list(
-          [{
-               'test_id' => 'foo',
-               'some_int' => 123
-           },
-           {
-               'test_id' => 'bar',
-               'some_int' => 124
-           }],
+          [{  'test_id' => 'foo',
+              'some_int' => 123 },
+           {  'test_id' => 'bar',
+              'some_int' => 124 }],
           topic: ''
         )
-      }.to raise_error(
-               RuntimeError,
-               'Topic not specified. Please specify the topic.'
-           )
-
+      }.to raise_error(RuntimeError,
+                       'Topic not specified. Please specify the topic.')
     end
 
     it 'should raise error if the producer has not been initialized with a topic' do
       expect {
         MyNoTopicProducer.publish_list(
-          [{
-               'test_id' => 'foo',
-               'some_int' => 123
-           },
-           {
-               'test_id' => 'bar',
-               'some_int' => 124
-           }]
+          [{  'test_id' => 'foo',
+              'some_int' => 123 },
+           {  'test_id' => 'bar',
+              'some_int' => 124 }]
         )
-      }.to raise_error(
-               RuntimeError,
-               'Topic not specified. Please specify the topic.'
-           )
+      }.to raise_error(RuntimeError,
+                       'Topic not specified. Please specify the topic.')
     end
 
     it 'should error with nothing set' do

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -64,6 +64,14 @@ module ProducerTest
       end
       stub_const('MyErrorProducer', producer_class)
 
+      producer_class = Class.new(Deimos::Producer) do
+        schema 'MySchema'
+        namespace 'com.my-namespace'
+        topic nil
+        key_config none: true
+      end
+      stub_const('MyNoTopicProducer', producer_class)
+
     end
 
     it 'should fail on invalid message with error handler' do
@@ -296,14 +304,22 @@ module ProducerTest
       )
     end
 
-    it 'should error if no topic is given' do
+    it 'should raise error if blank topic is passed in explicitly' do
       expect { MyProducer.publish_list(
           [{ 'test_id' => 'foo', 'some_int' => 123 },
            { 'test_id' => 'bar', 'some_int' => 124 }],
           topic: ""
       ) }.to raise_error(RuntimeError,
-                             'Topic not given! Please specify the topic.')
+                             'Topic not specified. Please specify the topic.')
 
+    end
+
+    it 'should raise error if the producer has not been initialized with a topic' do
+      expect { MyNoTopicProducer.publish_list(
+          [{ 'test_id' => 'foo', 'some_int' => 123 },
+           { 'test_id' => 'bar', 'some_int' => 124 }]
+      ) }.to raise_error(RuntimeError,
+                         'Topic not specified. Please specify the topic.')
     end
 
     it 'should error with nothing set' do

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -296,6 +296,16 @@ module ProducerTest
       )
     end
 
+    it 'should error if no topic is given' do
+      expect { MyProducer.publish_list(
+          [{ 'test_id' => 'foo', 'some_int' => 123 },
+           { 'test_id' => 'bar', 'some_int' => 124 }],
+          topic: ""
+      ) }.to raise_error(RuntimeError,
+                             'Topic not given! Please specify the topic.')
+
+    end
+
     it 'should error with nothing set' do
       expect {
         MyErrorProducer.publish_list(

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -305,21 +305,41 @@ module ProducerTest
     end
 
     it 'should raise error if blank topic is passed in explicitly' do
-      expect { MyProducer.publish_list(
-          [{ 'test_id' => 'foo', 'some_int' => 123 },
-           { 'test_id' => 'bar', 'some_int' => 124 }],
-          topic: ""
-      ) }.to raise_error(RuntimeError,
-                             'Topic not specified. Please specify the topic.')
+      expect {
+        MyProducer.publish_list(
+          [{
+               'test_id' => 'foo',
+               'some_int' => 123
+           },
+           {
+               'test_id' => 'bar',
+               'some_int' => 124
+           }],
+          topic: ''
+        )
+      }.to raise_error(
+               RuntimeError,
+               'Topic not specified. Please specify the topic.'
+           )
 
     end
 
     it 'should raise error if the producer has not been initialized with a topic' do
-      expect { MyNoTopicProducer.publish_list(
-          [{ 'test_id' => 'foo', 'some_int' => 123 },
-           { 'test_id' => 'bar', 'some_int' => 124 }]
-      ) }.to raise_error(RuntimeError,
-                         'Topic not specified. Please specify the topic.')
+      expect {
+        MyNoTopicProducer.publish_list(
+          [{
+               'test_id' => 'foo',
+               'some_int' => 123
+           },
+           {
+               'test_id' => 'bar',
+               'some_int' => 124
+           }]
+        )
+      }.to raise_error(
+               RuntimeError,
+               'Topic not specified. Please specify the topic.'
+           )
     end
 
     it 'should error with nothing set' do


### PR DESCRIPTION
# Pull Request Template

## Description

Changed the `publish_list` method in `lib/deimos/producer.rb` to raise error if the topic is blank.

Fixes #50 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests
- [x] Using the `ItemAttributeChangeProducer` in Fadmin

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
