### PR TITLE
GUILD-555: Don't resend messages when splitting up batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+### Fixes :wrench:
+- Do not resend already sent messages when splitting up batches
+  (fixes [#24](https://github.com/flipp-oss/deimos/issues/24))
+
 ## 1.8.2 - 2020-09-25
 
 ### Features :star:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,17 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 WORKDIR /opt/deimos
-COPY deimos.gemspec /opt/deimos/deimos.gemspec
+RUN gem update --system
+RUN gem install bundler
+COPY deimos-ruby.gemspec /opt/deimos/deimos-ruby.gemspec
 COPY lib/deimos/version.rb /opt/deimos/lib/deimos/version.rb
 COPY Gemfile /opt/deimos/Gemfile
 COPY Gemfile.lock /opt/deimos/Gemfile.lock
 
 RUN bundle install
 
-ADD . .
+COPY . /opt/deimos/
 
 ENTRYPOINT ["bundle", "exec"]
 
-CMD ["bundle", "exec", "rspec"]
+CMD ["bundle", "exec", "rspec", "--require spec_helper --tag integration"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,15 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 WORKDIR /opt/deimos
-RUN gem update --system
-RUN gem install bundler
-COPY deimos-ruby.gemspec /opt/deimos/deimos-ruby.gemspec
+COPY deimos.gemspec /opt/deimos/deimos.gemspec
 COPY lib/deimos/version.rb /opt/deimos/lib/deimos/version.rb
 COPY Gemfile /opt/deimos/Gemfile
 COPY Gemfile.lock /opt/deimos/Gemfile.lock
 
 RUN bundle install
 
-COPY . /opt/deimos/
+ADD . .
 
 ENTRYPOINT ["bundle", "exec"]
 
-CMD ["bundle", "exec", "rspec", "--require spec_helper --tag integration"]
+CMD ["bundle", "exec", "rspec"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Please see the following for further information not covered by this readme:
 * [Configuration Reference](docs/CONFIGURATION.md)
 * [Database Backend Feature](docs/DATABASE_BACKEND.md)
 * [Upgrading Deimos](docs/UPGRADING.md)
+* [Contributing to Integration Tests](docs/INTEGRATION_TESTS.md)
 
 # Installation
 

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1,0 +1,52 @@
+# Running Integration Tests
+
+This repo includes integration tests in the [spec/utils](spec/utils) directory.
+Here, there are tests for more deimos features that include a database integration like
+* [Database Poller](README.md#Database Poller)
+* [Database Backend](docs/DATABASE_BACKEND.md)
+* [Deadlock Retrying](lib/deimos/utils/deadlock_retry.rb)
+
+You will need to set up the following databases to develop and create unit tests in these test suites.
+* [SQLite](#SQLite)
+* [MySQL](#MySQL)
+* [PostgreSQL](#PostgreSQL)
+
+### SQLite
+This database is covered through the `sqlite3` gem. 
+
+## MySQL
+### Setting up a local MySQL server (Mac)
+```bash
+# Download MySQL (Optionally, choose a version you are comfortable with)
+brew install mysql
+# Start automatically after rebooting your machine
+brew services start mysql
+
+# Cleanup once you are done with MySQL
+brew services stop mysql
+```
+
+## PostgreSQL
+### Setting up a local PostgreSQL server (Mac)
+```bash
+# Install postgres if it's not already installed
+brew install postgres
+
+# Initialize and Start up postgres db
+brew services start postgres
+initdb /usr/local/var/postgres
+# Create the default database and user
+# Use the password "root"
+createuser -s --password postgres
+
+# Cleanup once done with Postgres
+killall postgres
+brew services stop postgres
+```
+
+## Running Integration Tests
+You must specify the tag "integration" when running these these test suites.
+This can be done through the CLI with the `--tag integration` argument.
+```bash
+rspec spec/utils/ --tag integration
+```

--- a/spec/utils/db_producer_spec.rb
+++ b/spec/utils/db_producer_spec.rb
@@ -98,7 +98,7 @@ each_db_config(Deimos::Utils::DbProducer) do
       expect(phobos_producer).to have_received(:publish_list).with(['A']).once
     end
 
-    it "should not resend batches of sent messages" do
+    it 'should not resend batches of sent messages' do
       allow(phobos_producer).to receive(:publish_list) do |group|
         raise Kafka::BufferOverflow if group.any?('A') && group.size >= 1000
         raise Kafka::BufferOverflow if group.any?('BIG') && group.size >= 10

--- a/spec/utils/db_producer_spec.rb
+++ b/spec/utils/db_producer_spec.rb
@@ -96,7 +96,32 @@ each_db_config(Deimos::Utils::DbProducer) do
       expect(phobos_producer).to have_received(:publish_list).with(['A'] * 100).once
       expect(phobos_producer).to have_received(:publish_list).with(['A'] * 10).once
       expect(phobos_producer).to have_received(:publish_list).with(['A']).once
+    end
 
+    it "should not resend batches of sent messages" do
+      allow(phobos_producer).to receive(:publish_list) do |group|
+        raise Kafka::BufferOverflow if group.any?('A') && group.size >= 1000
+        raise Kafka::BufferOverflow if group.any?('BIG') && group.size >= 10
+      end
+      allow(Deimos.config.metrics).to receive(:increment)
+      batch = ['A'] * 450 + ['BIG'] * 550
+      producer.produce_messages(batch)
+
+      expect(phobos_producer).to have_received(:publish_list).with(batch)
+      expect(phobos_producer).to have_received(:publish_list).with(['A'] * 100).exactly(4).times
+      expect(phobos_producer).to have_received(:publish_list).with(['A'] * 50 + ['BIG'] * 50)
+      expect(phobos_producer).to have_received(:publish_list).with(['A'] * 10).exactly(5).times
+      expect(phobos_producer).to have_received(:publish_list).with(['BIG'] * 1).exactly(550).times
+
+      expect(Deimos.config.metrics).to have_received(:increment).with('publish',
+                                                                      tags: %w(status:success topic:),
+                                                                      by: 100).exactly(4).times
+      expect(Deimos.config.metrics).to have_received(:increment).with('publish',
+                                                                      tags: %w(status:success topic:),
+                                                                      by: 10).exactly(5).times
+      expect(Deimos.config.metrics).to have_received(:increment).with('publish',
+                                                                      tags: %w(status:success topic:),
+                                                                      by: 1).exactly(550).times
     end
 
     describe '#compact_messages' do
@@ -289,6 +314,8 @@ each_db_config(Deimos::Utils::DbProducer) do
           message: "mess#{i}",
           partition_key: "key#{i}"
         )
+      end
+      (5..8).each do |i|
         Deimos::KafkaMessage.create!(
           id: i,
           topic: 'my-topic2',


### PR DESCRIPTION
# Pull Request Template

## Description

- Do not resend already sent messages when splitting up batches in db_producer
  - Uses a counter to keep track of the sent messages to kafka
  - When accessing the `batch`, index directly into the `Array[Hash]` to the current location of the batch
- Adds a document called INTEGRATION_TESTS.md for running integration tests such as db_poller and db_producer/db backend
- Updated integration unit tests for db_producer

Fixes #24 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?
- [x] Integration Unit Tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
