### PR TITLE
GUILD-574: Fix KafkaSource crashing on imports when import hooks are …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes :wrench:
 - Do not resend already sent messages when splitting up batches
   (fixes [#24](https://github.com/flipp-oss/deimos/issues/24))
+- KafkaSource crashing on bulk-imports if import hooks are disabled
+  (fixes [#73](https://github.com/flipp-oss/deimos/issues/73))
 
 ## 1.8.2 - 2020-09-25
 

--- a/lib/deimos/kafka_source.rb
+++ b/lib/deimos/kafka_source.rb
@@ -89,7 +89,7 @@ module Deimos
                                                   options={})
         results = super
         if !self.kafka_config[:import] || array_of_attributes.empty?
-          return ActiveRecord::Import::Result.new([], 0, [], [])
+          return results
         end
 
         # This will contain an array of hashes, where each hash is the actual

--- a/lib/deimos/kafka_source.rb
+++ b/lib/deimos/kafka_source.rb
@@ -88,8 +88,9 @@ module Deimos
                                                   array_of_attributes,
                                                   options={})
         results = super
-        return unless self.kafka_config[:import]
-        return if array_of_attributes.empty?
+        if !self.kafka_config[:import] || array_of_attributes.empty?
+          return ActiveRecord::Import::Result.new([], 0, [], [])
+        end
 
         # This will contain an array of hashes, where each hash is the actual
         # attribute hash that created the object.


### PR DESCRIPTION
…disabled

# Pull Request Template

## Description

Return `ActiveRecord::Import::Result.new([], 0, [], [])` when the kafka_config `import` is not set or the result set is empty.
Fixes an issue where KafkaSource crashes on bulk-imports if import hooks are disabled.

Fixes #73

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
