### PR TITLE
GUILD-569: Add validation for producer definition to KafkaSource module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 - Replaces `before` by `prepend_before` for more consistent test setups.
+- Adds validation in the `kafka_producers` method (fixes [#90](https://github.com/flipp-oss/deimos/issues/90))
 
 ## 1.8.7 - 2021-01-14
 


### PR DESCRIPTION

# Pull Request Template

## Description

The `kafka_producer` interface is outdated at this point and it's only there
for backwards compatibility. We're moving all the validation checks into the
`kafka_producers` and throwing a deprecation warning if the old interface is used.

Incidentally, this also takes care of the infinite loop we were seeing before when
no producer method was defined.

Fixes # (https://github.com/flipp-oss/deimos/issues/90)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration Unit Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
