### PR TITLE
Cpfm 246 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
-
+- Prevents DB Poller from reconnecting to DB if there is an open transaction
 - Replaces `before` by `prepend_before` for more consistent test setups.
 
 ## 1.8.7 - 2021-01-14

--- a/lib/deimos/utils/db_poller.rb
+++ b/lib/deimos/utils/db_poller.rb
@@ -68,7 +68,7 @@ module Deimos
 
       # Grab the PollInfo or create if it doesn't exist.
       def retrieve_poll_info
-        ActiveRecord::Base.connection.reconnect!
+        ActiveRecord::Base.connection.reconnect! unless ActiveRecord::Base.connection.open_transactions.positive?
         new_time = @config.start_from_beginning ? Time.new(0) : Time.zone.now
         @info = Deimos::PollInfo.find_by_producer(@config.producer_class) ||
                 Deimos::PollInfo.create!(producer: @config.producer_class,


### PR DESCRIPTION
…nsactions

# Pull Request Template

## Description

The DB poller functionality forces a DB reconnect, even when there is an open transaction. This creates complications when running specs, as the specs run in a transaction that then gets forcibly closed. This change is to prevent that from happening. 

Fixes #110 (issue)

## Type of change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ X ] Running any spec using the DB poller on a new service would fail prior to this. They don't fail anymore.

## Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ X ] My changes generate no new warnings
- [ X ] New and existing unit tests pass locally with my changes
