### PR TITLE
Cpfm 246

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
-
+- Prevents DB Poller from reconnecting to DB if there is an open transaction
 - Replaces `before` by `prepend_before` for more consistent test setups.
 
 ## 1.8.7 - 2021-01-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
-- Prevents DB Poller from reconnecting to DB if there is an open transaction
+- DB Poller orders results by record class timestamps, to prevent ambiguity from joins
 - Replaces `before` by `prepend_before` for more consistent test setups.
 
 ## 1.8.7 - 2021-01-14

--- a/lib/deimos/utils/db_poller.rb
+++ b/lib/deimos/utils/db_poller.rb
@@ -131,8 +131,8 @@ module Deimos
                              time_to: time_to,
                              column_name: @config.timestamp_column,
                              min_id: @info.last_sent_id).
-          limit(BATCH_SIZE).
-          order("#{quoted_timestamp}, #{quoted_id}")
+            limit(BATCH_SIZE).
+            order("#{@producer.config[:record_class].table_name}.#{quoted_timestamp}, #{quoted_id}")
       end
 
       # @param batch [Array<ActiveRecord::Base>]

--- a/lib/deimos/utils/db_poller.rb
+++ b/lib/deimos/utils/db_poller.rb
@@ -132,7 +132,7 @@ module Deimos
                              column_name: @config.timestamp_column,
                              min_id: @info.last_sent_id).
             limit(BATCH_SIZE).
-            order("#{quoted_timestamp}, #{quoted_id}")
+            order("#{@producer.config[:record_class].table_name}.#{quoted_timestamp}, #{quoted_id}")
       end
 
       # @param batch [Array<ActiveRecord::Base>]

--- a/lib/deimos/utils/db_poller.rb
+++ b/lib/deimos/utils/db_poller.rb
@@ -132,7 +132,7 @@ module Deimos
                              column_name: @config.timestamp_column,
                              min_id: @info.last_sent_id).
             limit(BATCH_SIZE).
-            order("#{@producer.config[:record_class].table_name}.#{quoted_timestamp}, #{quoted_id}")
+            order("#{quoted_timestamp}, #{quoted_id}")
       end
 
       # @param batch [Array<ActiveRecord::Base>]


### PR DESCRIPTION
Description
The DB Poller orders results by a timestamp (like updated_at, created_at, etc.), but if a join was done between multiple tables that share these timestamps, the order query becomes ambiguous, resulting in a crash. This fix sets the owner column for the timestamp to prevent this.

Fixes #112 (issue)

Type of change
Please delete options that are not relevant.

[ X ] Bug fix (non-breaking change which fixes an issue)
How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- Existing tests pass successfully. This is a bit of an edge case with my own project, so probably doesn't warrant a full test around it on Deimos. It's just making the ordering a bit more explicit. The service that uses this logic, Content Sieve, has tests that pass with this fix.

[ X ] My code follows the style guidelines of this project
[ X ] I have performed a self-review of my own code
[ X ]I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
[ X ] My changes generate no new warnings
[ X ] New and existing unit tests pass locally with my changes