### PR TITLE
GUILD-619: Test helpers don't automatically reset to test config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
+### Roadmap :car:
+
+- TestHelper does not automatically reset Deimos config before each test. #120
 
 ## 1.10.0 - 2021-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 ### Roadmap :car:
 
-- TestHelper does not automatically reset Deimos config before each test. [#120](https://github.com/flipp-oss/deimos/pull/120)
+- TestHelper does not automatically reset Deimos config before each test. [#120](https://github.com/flipp-oss/deimos/pull/120).
+  **Please note that this is a breaking change**
 
 ## 1.10.0 - 2021-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 ### Roadmap :car:
 
-- TestHelper does not automatically reset Deimos config before each test. #120
+- TestHelper does not automatically reset Deimos config before each test. [#120](https://github.com/flipp-oss/deimos/pull/120)
 
 ## 1.10.0 - 2021-03-22
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Built on Phobos and hence Ruby-Kafka.
    * [Running Consumers](#running-consumers)
    * [Metrics](#metrics)
    * [Testing](#testing)
+        * [Default Deimos config for testing](#default-deimos-config-for-testing)
         * [Integration Test Helpers](#integration-test-helpers)
    * [Utilities](#utilities)
    * [Contributing](#contributing) 

--- a/README.md
+++ b/README.md
@@ -950,7 +950,7 @@ Deimos::TestHelpers.schemas_compatible?(schema1, schema2)
 ### Test Helpers
 
 There are helper methods available to configure Deimos for different types of testing scenarios. 
-Currently there is a helper defined for unit tests and for testing Kafka releated code. You can use it as follows:
+Currently there are helpers defined for unit tests and for testing Kafka related code. You can use it as follows:
 
 ```ruby
 # The following can be added to a rpsec file so that each unit 
@@ -961,10 +961,16 @@ around(:each) do |example|
   Deimos.config.reset
 end
 
-
 # Similarly you can use the Kafka test helper
 around(:each) do |example|
-  Deimos::TestHelpers.kafka_test
+  Deimos::TestHelpers.kafka_test!
+  example.run
+  Deimos.config.reset
+end
+
+# Kakfa test helper using schema registry
+around(:each) do |example|
+  Deimos::TestHelpers.kafka_schema_registry_test!
   example.run
   Deimos.config.reset
 end
@@ -972,6 +978,23 @@ end
 
 With the help of these helper methods, rspec examples can be written without having to tinker with Deimos settings.
 This also prevents Deimos setting changes from leaking in to other examples.
+
+This does not take away the ability to configure Deimos manually in individual examples. Deimos can still be configured like so:
+```ruby
+    it 'should not fail this random test' do
+      
+      Deimos.configure do |config|
+        config.consumers.fatal_error = proc { true }
+        config.consumers.reraise_errors = false
+      end
+      ...
+      expect(some_object).to be_truthy
+      ...
+    end
+```
+If you are using one of the test helpers in an `around(:each)` block and want to override few settings for one example, 
+you can do it like in the example shown above. These settings would only apply to that specific example and the Deimos conifg should
+reset once the example has finished running.
 
 
 ### Integration Test Helpers

--- a/README.md
+++ b/README.md
@@ -958,21 +958,21 @@ Currently there are helpers defined for unit tests and for testing Kafka related
 around(:each) do |example|
   Deimos::TestHelpers.unit_test!
   example.run
-  Deimos.config.reset
+  Deimos.config.reset!
 end
 
 # Similarly you can use the Kafka test helper
 around(:each) do |example|
   Deimos::TestHelpers.kafka_test!
   example.run
-  Deimos.config.reset
+  Deimos.config.reset!
 end
 
 # Kakfa test helper using schema registry
 around(:each) do |example|
-  Deimos::TestHelpers.kafka_schema_registry_test!
+  Deimos::TestHelpers.full_integration_test!
   example.run
-  Deimos.config.reset
+  Deimos.config.reset!
 end
 ```
 
@@ -990,6 +990,7 @@ This does not take away the ability to configure Deimos manually in individual e
       ...
       expect(some_object).to be_truthy
       ...
+      Deimos.config.reset!
     end
 ```
 If you are using one of the test helpers in an `around(:each)` block and want to override few settings for one example, 

--- a/README.md
+++ b/README.md
@@ -935,6 +935,18 @@ expect(message).to eq({
   topic: 'my-topic',
   key: 'my-id'
 })
+
+## Configuring Deimos to test settings
+
+# You can reset Deimos to default test config by calling this method.
+configure_deimos
+
+# The same method can be used to override settings while still using
+# deafults for other fields.
+configure_deimos(consumers: { reraise_errors: false },
+                 producers: { topic_prefix: nil },
+                 db_producer: { compact_topics: %w(my-topic my-topic2) },
+                 logger: Rails.logger)
 ```
 
 There is also a helper method that will let you test if an existing schema

--- a/README.md
+++ b/README.md
@@ -958,6 +958,28 @@ require 'deimos/test_helpers'
 # Can pass a file path, a string or a hash into this:
 Deimos::TestHelpers.schemas_compatible?(schema1, schema2)
 ```
+### Default Deimos config for testing
+
+The test helper class provides the default settings for Deimos config.
+```ruby
+# The following are the test defaults for Deimos that are set
+# by calling `configure_deimos` 
+DEFAULT_TEST_CONFIG = {
+  logger: Logger.new(STDOUT),
+  consumers: { reraise_errors: true },
+  kafka: { seed_brokers: ['test_broker'] },
+  schema: { backend: Deimos.schema_backend_class.mock_backend },
+  producers: { backend: :test }
+}
+```
+`:test` is the default backend for producers that saves messages
+to an in-memory hash. You can access the sent messages by calling 
+the following function
+```ruby
+Deimos::Backends::Test.sent_messages
+```
+Mock schema backend will perform all the validations but not actually encode any messages.
+
 
 ### Integration Test Helpers
 

--- a/lib/deimos/test_helpers.rb
+++ b/lib/deimos/test_helpers.rb
@@ -45,6 +45,28 @@ module Deimos
 
     end
 
+    def configure_deimos(options)
+      Deimos.configure do |d_config|
+        options.each do |key, value|
+          # If the config options are nested.
+          # Assuming that there is only one level of nesting
+          if value.is_a?(Hash)
+            value.each do |k,v|
+              d_config.send(key.to_sym).send(k.to_sym, v)
+            end
+          #  If the values are not nested, then simply assign them
+          else
+            d_config.send(key.to_sym, value)
+          end
+        end
+        # d_config.logger = options[:logger] || Logger.new(STDOUT)
+        # d_config.consumers.reraise_errors = options[:reraise_consumers_errors]
+        # d_config.kafka.seed_brokers ||= options[:kafka_seed_brokers] || ['test_broker']
+        # d_config.schema.backend = options[:schema_backend] || Deimos.schema_backend_class.mock_backend
+        # d_config.producers.backend = options[:producers_backend] || :test
+      end
+    end
+
     # @deprecated
     def stub_producers_and_consumers!
       warn('stub_producers_and_consumers! is no longer necessary and this method will be removed in 3.0')

--- a/lib/deimos/test_helpers.rb
+++ b/lib/deimos/test_helpers.rb
@@ -31,7 +31,7 @@ module Deimos
       end
 
       # Kafka test config with avro schema registry
-      def kafka_schema_registry_test!
+      def full_integration_test!
         Deimos.configure do |deimos_config|
           deimos_config.producers.backend = :kafka
           deimos_config.schema.backend = :avro_schema_registry

--- a/lib/deimos/test_helpers.rb
+++ b/lib/deimos/test_helpers.rb
@@ -30,6 +30,14 @@ module Deimos
         end
       end
 
+      # Kafka test config with avro schema registry
+      def kafka_schema_registry_test!
+        Deimos.configure do |deimos_config|
+          deimos_config.producers.backend = :kafka
+          deimos_config.schema.backend = :avro_schema_registry
+        end
+      end
+
       # Set the config to the right settings for a kafka test
       def kafka_test!
         Deimos.configure do |deimos_config|

--- a/lib/deimos/test_helpers.rb
+++ b/lib/deimos/test_helpers.rb
@@ -45,13 +45,15 @@ module Deimos
 
     end
 
+    # Call in your examples to configure Deimos
+    # @param options <Hash>
     def configure_deimos(options)
       Deimos.configure do |d_config|
         options.each do |key, value|
           # If the config options are nested.
           # Assuming that there is only one level of nesting
           if value.is_a?(Hash)
-            value.each do |k,v|
+            value.each do |k, v|
               d_config.send(key.to_sym).send(k.to_sym, v)
             end
           #  If the values are not nested, then simply assign them
@@ -59,11 +61,6 @@ module Deimos
             d_config.send(key.to_sym, value)
           end
         end
-        # d_config.logger = options[:logger] || Logger.new(STDOUT)
-        # d_config.consumers.reraise_errors = options[:reraise_consumers_errors]
-        # d_config.kafka.seed_brokers ||= options[:kafka_seed_brokers] || ['test_broker']
-        # d_config.schema.backend = options[:schema_backend] || Deimos.schema_backend_class.mock_backend
-        # d_config.producers.backend = options[:producers_backend] || :test
       end
     end
 


### PR DESCRIPTION
## Description

- Deimos is not reset back to the default test config before each test now.
- A function has been added which can be called by clients in tests to manually reset Deimos back to test config.
- The same function can also be used to override settings while keeping defaults in place.

Fixes https://flippit.atlassian.net/browse/GUILD-619

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tested by calling this function in existing specs locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
