### PR TITLE
Fix for changing Deimos:: to Schema:: module namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- ### Fixes :wrench:
+- Fixed issue where Schema Class Consumer/Producer are using `Deimos::` instead of `Schema::` for instances of classes.
+
 # 1.12.0 - 2021-11-01
 
 ### Features :star:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deimos-ruby (1.11.0)
+    deimos-ruby (1.12.0)
       avro_turf (~> 0.11)
       fig_tree (~> 0.0.2)
       phobos (>= 1.9, < 3.0)

--- a/lib/deimos/schema_class/base.rb
+++ b/lib/deimos/schema_class/base.rb
@@ -17,7 +17,7 @@ module Deimos
         to_h.to_json
       end
 
-      # Converts the object to a hash which can be used for debugging.
+      # Converts the object to a hash which can be used for debugging or comparing objects.
       # @return [Hash] a hash representation of the payload
       def as_json(_opts={})
         JSON.parse(to_json)
@@ -33,10 +33,10 @@ module Deimos
       def ==(other)
         comparison = other
         if other.class == self.class
-          comparison = other.state
+          comparison = other.as_json
         end
 
-        comparison == self.state
+        comparison == self.as_json
       end
 
       # :nodoc:
@@ -54,13 +54,8 @@ module Deimos
     protected
 
       # :nodoc:
-      def state
-        as_json
-      end
-
-      # :nodoc:
       def hash
-        state.hash
+        as_json.hash
       end
     end
   end

--- a/lib/deimos/schema_class/record.rb
+++ b/lib/deimos/schema_class/record.rb
@@ -7,14 +7,11 @@ module Deimos
   module SchemaClass
     # Base Class of Record Classes generated from Avro.
     class Record < Base
-      # :nodoc:
-      def ==(other)
-        comparison = other
-        if other.class == self.class
-          comparison = other.state
-        end
 
-        comparison.stringify_keys.except('payload_key') == self.state.except('payload_key')
+      # Converts the object to a hash which can be used for debugging or comparing objects.
+      # @return [Hash] a hash representation of the payload
+      def as_json(_opts={})
+        super.except('payload_key')
       end
 
       # Element access method as if this Object were a hash

--- a/lib/deimos/schema_class/record.rb
+++ b/lib/deimos/schema_class/record.rb
@@ -7,6 +7,16 @@ module Deimos
   module SchemaClass
     # Base Class of Record Classes generated from Avro.
     class Record < Base
+      # :nodoc:
+      def ==(other)
+        comparison = other
+        if other.class == self.class
+          comparison = other.state
+        end
+
+        comparison.stringify_keys.except('payload_key') == self.state.except('payload_key')
+      end
+
       # Element access method as if this Object were a hash
       # @param key[String||Symbol]
       # @return [Object] The value of the attribute if exists, nil otherwise

--- a/lib/deimos/utils/schema_class.rb
+++ b/lib/deimos/utils/schema_class.rb
@@ -10,7 +10,7 @@ module Deimos
         # @param schema [String]
         # @return [Deimos::SchemaClass::Record]
         def instance(payload, schema)
-          klass = "Deimos::#{schema.underscore.camelize}".safe_constantize
+          klass = "Schemas::#{schema.underscore.camelize}".safe_constantize
           return payload if klass.nil? || payload.nil?
 
           klass.new(**payload.symbolize_keys)

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -12,7 +12,7 @@ module ConsumerTest
 
         # :nodoc:
         def fatal_error?(_exception, payload, _metadata)
-          payload == 'fatal'
+          payload.to_s == 'fatal'
         end
 
         # :nodoc:


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes issue that was released with #122 - `Deimos` namespace was used previously for generated Schema Classes. Updated to use the `Schema` namespace and updated rspecs that were previously missed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested on applications that were not working with #122. Fixed on those apps.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
