### PR TITLE
Fix for schema controller mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+# 1.12.4 - 2022-01-13
+
+- Fix bug where schema controller mixin was using the schema name to register and not the namespaced schema name
+
 # 1.12.3 - 2021-12-13
 
 - Fix bug with previous release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deimos-ruby (1.12.0)
+    deimos-ruby (1.12.3)
       avro_turf (~> 0.11)
       fig_tree (~> 0.0.2)
       phobos (>= 1.9, < 3.0)
@@ -92,7 +92,7 @@ GEM
       rake (>= 12.0.0, < 14.0.0)
     dogstatsd-ruby (4.8.3)
     erubi (1.10.0)
-    excon (0.85.0)
+    excon (0.89.0)
     exponential-backoff (0.0.4)
     ffi (1.15.0)
     fig_tree (0.0.2)

--- a/lib/deimos/utils/schema_controller_mixin.rb
+++ b/lib/deimos/utils/schema_controller_mixin.rb
@@ -106,7 +106,7 @@ module Deimos
       def render_schema(payload, schema: nil, namespace: nil)
         namespace, schema = parse_namespace(:response) if !schema && !namespace
         encoder = Deimos.schema_backend(schema: schema, namespace: namespace)
-        encoded = encoder.encode(payload)
+        encoded = encoder.encode(payload, topic: "#{namespace}.#{schema}")
         response.headers['Content-Type'] = encoder.class.content_type
         send_data(encoded)
       end

--- a/lib/deimos/version.rb
+++ b/lib/deimos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Deimos
-  VERSION = '1.12.2'
+  VERSION = '1.12.4'
 end


### PR DESCRIPTION
- Fix bug where schema controller mixin was using the schema name to register and not the namespaced schema name.