### PR TITLE
Fix `schema.generated_class_path` configuration name

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -179,7 +179,7 @@ schema.backend|`:mock`|Backend representing the schema encoder/decoder. You can 
 schema.registry_url|`http://localhost:8081`|URL of the Confluent schema registry.
 schema.path|nil|Local path to find your schemas.
 schema.use_schema_classes|false|Set this to true to use generated schema classes in your application.
-schema.generated_schema_path|`app/lib/schema_classes`|Local path to generated schema classes.
+schema.generated_class_path|`app/lib/schema_classes`|Local path to generated schema classes.
 
 ## Database Producer Configuration
 


### PR DESCRIPTION
## Description

The `CONFIGURATION.md` doc seems to have an outdated or incorrect configuration field.
It references a `schema.generated_schema_path`, but looking at the code and the README the correct name seems to be `schema.generated_class_path`

## Type of change

- [x] This change requires a documentation update