### PR TITLE
Confluent Cloud support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 - Allow use of new avro_turf versions where child schemas are not listed with the top level schemas
+- Add support for SASL authentication with brokers
+- Add support for Basic auth with Schema Registry
 
 # 1.12.4 - 2022-01-13
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -130,9 +130,21 @@ kafka.client_id|`phobos`|Identifier for this application.
 kafka.connect_timeout|15|The socket timeout for connecting to the broker, in seconds.
 kafka.socket_timeout|15|The socket timeout for reading and writing to the broker, in seconds.
 kafka.ssl.enabled|false|Whether SSL is enabled on the brokers.
+kafka.ssl.ca_certs_from_system|false|Use CA certs from system.
 kafka.ssl.ca_cert|nil| A PEM encoded CA cert, a file path to the cert, or an Array of certs to use with an SSL connection.
 kafka.ssl.client_cert|nil|A PEM encoded client cert to use with an SSL connection, or a file path to the cert.
 kafka.ssl.client_cert_key|nil|A PEM encoded client cert key to use with an SSL connection.
+kafka.sasl.enabled|false|Whether SASL is enabled on the brokers.
+kafka.sasl.gssapi_principal|nil|A KRB5 principal.
+kafka.sasl.gssapi_keytab|nil|A KRB5 keytab filepath.
+kafka.sasl.plain_authzid|nil|Plain authorization ID.
+kafka.sasl.plain_username|nil|Plain username.
+kafka.sasl.plain_password|nil|Plain password.
+kafka.sasl.scram_username|nil|SCRAM username.
+kafka.sasl.scram_password|nil|SCRAM password.
+kafka.sasl.scram_mechanism|nil|Scram mechanism, either "sha256" or "sha512".
+kafka.sasl.enforce_ssl|nil|Whether to enforce SSL with SASL.
+kafka.sasl.oauth_token_provider|nil|OAuthBearer Token Provider instance that implements method token. See {Sasl::OAuth#initialize}.
 
 ## Consumer Configuration
 
@@ -177,6 +189,8 @@ Config name|Default|Description
 -----------|-------|-----------
 schema.backend|`:mock`|Backend representing the schema encoder/decoder. You can see a full list [here](../lib/deimos/schema_backends).
 schema.registry_url|`http://localhost:8081`|URL of the Confluent schema registry.
+schema.user|nil|Basic auth user.
+schema.password|nil|Basic auth password.
 schema.path|nil|Local path to find your schemas.
 schema.use_schema_classes|false|Set this to true to use generated schema classes in your application.
 schema.generated_class_path|`app/lib/schema_classes`|Local path to generated schema classes.

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -324,6 +324,10 @@ module Deimos
       # @return [String]
       setting :registry_url, 'http://localhost:8081'
 
+      setting :user
+
+      setting :password
+
       # Local path to look for schemas in.
       # @return [String]
       setting :path

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -136,6 +136,58 @@ module Deimos
 
         # Verify certificate hostname if supported (ruby >= 2.4.0)
         setting :verify_hostname, true
+
+        # Use CA certs from system. This is useful to have enabled for Confluent Cloud
+        # @return [Boolean]
+        setting :ca_certs_from_system, false
+      end
+
+      setting :sasl do
+        # Whether SASL is enabled on the brokers.
+        # @return [Boolean]
+        setting :enabled
+
+        # A KRB5 principal.
+        # @return [String]
+        setting :gssapi_principal
+
+        # A KRB5 keytab filepath.
+        # @return [String]
+        setting :gssapi_keytab
+
+        # Plain authorization ID. It needs to default to '' in order for it to work.
+        # This is because Phobos expects it to be truthy for using plain SASL.
+        # @return [String]
+        setting :plain_authzid, ''
+
+        # Plain username.
+        # @return [String]
+        setting :plain_username
+
+        # Plain password.
+        # @return [String]
+        setting :plain_password
+
+        # SCRAM username.
+        # @return [String]
+        setting :scram_username
+
+        # SCRAM password.
+        # @return [String]
+        setting :scram_password
+
+        # Scram mechanism, either "sha256" or "sha512".
+        # @return [String]
+        setting :scram_mechanism
+
+        # Whether to enforce SSL with SASL.
+        # @return [Boolean]
+        setting :enforce_ssl
+
+        # OAuthBearer Token Provider instance that implements
+        # method token. See {Sasl::OAuth#initialize}.
+        # @return [Object]
+        setting :oauth_token_provider
       end
     end
 

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -324,8 +324,12 @@ module Deimos
       # @return [String]
       setting :registry_url, 'http://localhost:8081'
 
+      # Basic Auth user.
+      # @return [String]
       setting :user
 
+      # Basic Auth password.
+      # @return [String]
       setting :password
 
       # Local path to look for schemas in.

--- a/lib/deimos/schema_backends/avro_schema_registry.rb
+++ b/lib/deimos/schema_backends/avro_schema_registry.rb
@@ -26,6 +26,8 @@ module Deimos
           schema_store: @schema_store,
           registry_url: Deimos.config.schema.registry_url,
           schemas_path: Deimos.config.schema.path,
+          user: Deimos.config.schema.user,
+          password: Deimos.config.schema.password,
           namespace: @namespace
         )
       end

--- a/spec/config/configuration_spec.rb
+++ b/spec/config/configuration_spec.rb
@@ -70,6 +70,7 @@ describe Deimos, 'configuration' do
         connect_timeout: 15,
         socket_timeout: 15,
         ssl_verify_hostname: true,
+        ssl_ca_certs_from_system: false,
         seed_brokers: ['localhost:9092']
       },
       listeners: [
@@ -138,10 +139,22 @@ describe Deimos, 'configuration' do
         connect_timeout 30
         socket_timeout 30
         ssl.enabled(true)
+        ssl.ca_certs_from_system(true)
         ssl.ca_cert('cert')
         ssl.client_cert('cert')
         ssl.client_cert_key('key')
         ssl.verify_hostname(false)
+        sasl.enabled true
+        sasl.gssapi_principal 'gssapi_principal'
+        sasl.gssapi_keytab 'gssapi_keytab'
+        sasl.plain_authzid 'plain_authzid'
+        sasl.plain_username 'plain_username'
+        sasl.plain_password 'plain_password'
+        sasl.scram_username 'scram_username'
+        sasl.scram_password 'scram_password'
+        sasl.scram_mechanism 'scram_mechanism'
+        sasl.enforce_ssl true
+        sasl.oauth_token_provider 'oauth_token_provider'
       end
       consumers do
         session_timeout 30
@@ -210,11 +223,22 @@ describe Deimos, 'configuration' do
           client_id: 'phobos2',
           connect_timeout: 30,
           socket_timeout: 30,
+          ssl_ca_certs_from_system: true,
           ssl_ca_cert: 'cert',
           ssl_client_cert: 'cert',
           ssl_client_cert_key: 'key',
           ssl_verify_hostname: false,
-          seed_brokers: ['my-seed-brokers']
+          seed_brokers: ['my-seed-brokers'],
+          sasl_gssapi_principal: 'gssapi_principal',
+          sasl_gssapi_keytab: 'gssapi_keytab',
+          sasl_plain_authzid: 'plain_authzid',
+          sasl_plain_username: 'plain_username',
+          sasl_plain_password: 'plain_password',
+          sasl_scram_username: 'scram_username',
+          sasl_scram_password: 'scram_password',
+          sasl_scram_mechanism: 'scram_mechanism',
+          sasl_over_ssl: true,
+          sasl_oauth_token_provider: 'oauth_token_provider',
         },
         listeners: [
           {


### PR DESCRIPTION
## Summary

Add support for Confluent Cloud, by adding SASL authentication.
Fixes #133

## Description

This PR solves 2 authentication issues with Confluent Cloud:
1. Provide SASL authentication when connecting to a Confluent Cloud Kafka cluster
2. Provide  Basic authentication when connecting to a Confluent Cloud Schema Registry

The issue at the moment is that the latter change relies on a change in `avro_turf` that was [introduced here](https://github.com/dasch/avro_turf/pull/121), and only released as part of v1.3.0. However `deimos` currently depends on `avro_turf ~> 0.11`, and when I tried relaxing the dependency to allow for `avro_turf 1.x`, I got an error with the schema classes generator.

I managed to pinpoint the issue to a [breaking change](https://github.com/dasch/avro_turf/pull/111) that was released with `avro_turf 1.0`. There were even plans to bring support for it since 2020 (#67), but I see no progress has been made since then.

@dorner any guidance on this would be welcome. I haven't spent enough time with Deimos to feel confident fixing this compatibility issue and I'm not sure I understand your proposal about a "singleton encoder/decoder".
If this is too complicated or lengthy to implement, I might opt for temporarily monkey-patching `avro_turf` by cherry picking the basic auth change commit.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Add unit tests
- [x] Test with private Rails application using Confluent Cloud

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules