### PR TITLE
Fix NameError when using Datadog Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Fix NameError when using Datadog Metrics
+
 # 1.12.5 - 2022-03-09
 
 - Allow use of new avro_turf versions where child schemas are not listed with the top level schemas

--- a/lib/deimos/metrics/datadog.rb
+++ b/lib/deimos/metrics/datadog.rb
@@ -13,7 +13,7 @@ module Deimos
         raise 'Metrics config must specify namespace' if config[:namespace].nil?
 
         logger.info("DatadogMetricsProvider configured with: #{config}")
-        @client = Datadog::Statsd.new(
+        @client = ::Datadog::Statsd.new(
           config[:host_ip],
           config[:host_port]
         )


### PR DESCRIPTION
# Pull Request Template

## Description

Due to namespace clashing, `Deimos::Metrics::Datadog` is currently raising `uninitialized constant Deimos::Metrics::Datadog::Statsd (NameError)` when used.
This can easily be fixed by adding a `::`prefix to `Datadog::Statsd`.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The issue could be easily reproduced by using the Datadog Metrics adapter in our app.
Deimos configuration:

```ruby
Deimos.configure do
  metrics Deimos::Metrics::Datadog.new(...)
end
```

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
