### PR TITLE
Fix metrics and tracing defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 - Fix NameError when using Datadog Metrics
+- Fix unwanted STDOUT output when loading the main `Deimos` module
 
 # 1.12.5 - 2022-03-09
 

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'deimos'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+IRB.start(__FILE__)

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -347,11 +347,11 @@ module Deimos
 
     # The configured metrics provider.
     # @return [Metrics::Provider]
-    setting :metrics, Metrics::Mock.new
+    setting :metrics, default_proc: proc { Metrics::Mock.new }
 
     # The configured tracing / APM provider.
     # @return [Tracing::Provider]
-    setting :tracer, Tracing::Mock.new
+    setting :tracer, default_proc: proc { Tracing::Mock.new }
 
     setting :db_producer do
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the initialization of the 2 mock providers would cause unwanted logs to be sent to STDOUT.
This is because the default values for `metrics` and `tracer` currently call the `#initialize` method in both `Metrics::Mock` and `Tracing::Mock` while the Deimos class is loaded.

There's currently no way to avoid that, including specifying a custom value for these settings.

This PR also includes a new `bin/console` script which allows developers to load up an IRB console with the local `deimos` gem loaded. This is a pretty common script (it's autogenerated in new gems nowadays), useful for testing uncommitted changes. It's been added in this PR because it makes it really easy to see the problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Since this issue happens when the `Deimos` is first loaded, it wasn't possible to write an RSpec test for this change.
Instead, the new `bin/console` makes demonstrating this issue very easy.

If you checkout this PR, revert `lib/deimos/configuration.rb` to it's previous state, and then run `bin/console`, you'll see the following:

```bash
❯ bin/console              
I, [2022-03-14T14:53:32.827703 #39523]  INFO -- : MockMetricsProvider initialized
I, [2022-03-14T14:53:32.827748 #39523]  INFO -- : MockTracingProvider initialized
2.6.8 :001 > 
```

As you can see, the two mock providers log to STDOUT as a result of `require 'deimos'`.
This happens even if you call `Deimos.configure` and pass a custom value for `metrics` and `tracer`.

If you now apply the changes to `lib/deimos/configuration.rb` included in this PR and run `bin/console` again, that won't happen anymore:

```bash
❯ bin/console
2.6.8 :001 >
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
