### PR TITLE
Fix sigurd require by requiring the top-level module instead of individual classes.

### DIFF
--- a/lib/deimos.rb
+++ b/lib/deimos.rb
@@ -33,8 +33,7 @@ if defined?(ActiveRecord)
   require 'deimos/kafka_source'
   require 'deimos/kafka_topic_info'
   require 'deimos/backends/db'
-  require 'sigurd/signal_handler'
-  require 'sigurd/executor'
+  require 'sigurd'
   require 'deimos/utils/db_producer'
   require 'deimos/utils/db_poller'
 end

--- a/lib/deimos/utils/db_poller.rb
+++ b/lib/deimos/utils/db_poller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require 'deimos/poll_info'
-require 'sigurd/executor'
-require 'sigurd/signal_handler'
+require 'sigurd'
 
 module Deimos
   module Utils


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes [an issue](https://github.com/flipp-oss/deimos/runs/7436367328?check_suite_focus=true#step:4:1418) with the new `exit_on_signal` config that is defined in the top-level module.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] The test that was previously failing is now passing
- [x] Deploy this branch on our staging application and check that the error doesn't appear anymore