### PR TITLE
Tracer should be Tracing

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -15,7 +15,7 @@ Config name|Default|Description
 logger|`Logger.new(STDOUT)`|The logger that Deimos will use.
 phobos_logger|`Deimos.config.logger`|The logger passed to Phobos.
 metrics|`Deimos::Metrics::Mock.new`|The metrics backend use for reporting.
-tracer|`Deimos::Tracer::Mock.new`|The tracer backend used for debugging.
+tracer|`Deimos::Tracing::Mock.new`|The tracer backend used for debugging.
 
 ## Defining Producers
 


### PR DESCRIPTION
# Pull Request Template

## Description

In Basic Configuration, "Tracer" is used where "Tracing" is meant.

## Type of change
Documentation typo.

## How Has This Been Tested?
Copied config entry as it was in the documentation got error, changed documentation to match what works.

## Checklist:
I just deleted the checklist because none seem to apply to doc change only.