### PR TITLE
State Based Mode: change the detection of primary_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Fix the primary_key detection way in `state_based` mode
+
 # 1.18.0 - 2022-11-01
 
 ### Features :star:

--- a/lib/deimos/utils/db_poller/state_based.rb
+++ b/lib/deimos/utils/db_poller/state_based.rb
@@ -39,7 +39,7 @@ module Deimos
 
           state = success ? @config.published_state : @config.failed_state
           klass = batch.first.class
-          id_col = record.class.primary_key
+          id_col = klass.primary_key.to_sym
           timestamp_col = @config.timestamp_column
 
           attrs = { timestamp_col => Time.zone.now }


### PR DESCRIPTION
## Description

Change the detection methods for primary_key in state_based mode

Fixes # (issue)

Bug in DB updates according to primary_key detection 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
