### PR TITLE
poll info is updated when no records are fetched. This enables should…

### DIFF
--- a/lib/deimos/utils/db_poller/state_based.rb
+++ b/lib/deimos/utils/db_poller/state_based.rb
@@ -18,7 +18,10 @@ module Deimos
           loop do
             Deimos.config.logger.debug("Polling #{@producer.topic}, batch #{status.current_batch}")
             batch = fetch_results.to_a
-            break if batch.empty?
+            if batch.empty?
+              @info.touch(:last_sent)
+              break
+            end
 
             success = process_batch_with_span(batch, status)
             finalize_batch(batch, success)
@@ -35,7 +38,7 @@ module Deimos
         # @param success [Boolean]
         # @return [void]
         def finalize_batch(batch, success)
-          @info.touch
+          @info.touch(:last_sent)
 
           state = success ? @config.published_state : @config.failed_state
           klass = batch.first.class

--- a/lib/deimos/utils/db_poller/time_based.rb
+++ b/lib/deimos/utils/db_poller/time_based.rb
@@ -36,7 +36,10 @@ module Deimos
           loop do
             Deimos.config.logger.debug("Polling #{@producer.topic}, batch #{status.current_batch}")
             batch = fetch_results(time_from, time_to).to_a
-            break if batch.empty?
+            if batch.empty?
+              @info.touch(:last_sent)
+              break
+            end
 
             process_and_touch_info(batch, status)
             time_from = last_updated(batch.last)

--- a/spec/utils/db_poller_spec.rb
+++ b/spec/utils/db_poller_spec.rb
@@ -333,6 +333,20 @@ each_db_config(Deimos::Utils::DbPoller::Base) do
           with('Poll my-topic-with-id complete at 2015-05-05 00:59:58 -0400 (3 batches, 0 errored batches, 7 processed messages)')
       end
 
+      it 'should update PollInfo timestamp after processing' do
+        poll_before = Deimos::PollInfo.last
+        poller.process_updates
+        poll_after = Deimos::PollInfo.last
+        expect(poll_after.last_sent).to be >= poll_before.last_sent
+      end
+
+      it 'should update PollInfo timestamp when there are no records to process' do
+        allow(poller).to receive(:fetch_results).and_return([])
+        poll_before = Deimos::PollInfo.last
+        poller.process_updates
+        poll_after = Deimos::PollInfo.last
+        expect(poll_after.last_sent).to be >= poll_before.last_sent
+      end
       describe 'errors' do
         before(:each) do
           poller.config.retries = 0


### PR DESCRIPTION
…_run to wait for `run_every` seconds before next round of processing updates

# Pull Request Template

## Description

DBPoller -- state and time based currently polls and waits for `run_every`(default=60 seconds) after every run.
However, if batch to process returns zero rows, it immediately runs the next loop and it continues again and again until it finds a valid set of items. After which it waits for 60 seconds as expected.

Expectation: It is expected to wait for 60 seconds in scenarios where batch returns zero rows.

This PR fixes the "not waiting" issue by saving last_sent to PollInfo in the scenario where batch of records to process is empty.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- Ran State based poller and time based poller locally and simulated the scenario of having a huge batch of records to process. Observed that it waits for 60 seconds after processing is complete.
- Replicated the same scenario with zero records qualified by poll query. It now waits for 60 seconds after no records are found.

- Repeated first scenario for state based poller
- Repeated second scenario for state based poller

## Checklist:

- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
