### PR TITLE
CHP-1000: Add option to limit database queries to a maximum size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Feature: Limit amount of transactions in a single database call with `max_db_batch_size`
+
 # 1.19.0 - 2023-02-21
 
 - Feature: When consuming data in batch mode, this adds ability to save data to multiple tables with `association_list`.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -83,6 +83,7 @@ key_config|nil|Configuration hash for message keys. See [Kafka Message Keys](../
 disabled|false|Set to true to skip starting an actual listener for this consumer on startup.
 group_id|nil|ID of the consumer group.
 use_schema_classes|nil|Set to true or false to enable or disable using the consumers schema classes. See [Generated Schema Classes](../README.md#generated-schema-classes)
+max_db_batch_size|nil|Maximum limit for batching database calls to reduce the load on the db.
 max_concurrency|1|Number of threads created for this listener. Each thread will behave as an independent consumer. They don't share any state.
 start_from_beginning|true|Once the consumer group has checkpointed its progress in the topic's partitions, the consumers will always start from the checkpointed offsets, regardless of config. As such, this setting only applies when the consumer initially starts consuming from a topic
 max_bytes_per_partition|512.kilobytes|Maximum amount of data fetched from a single partition at a time.

--- a/lib/deimos/active_record_consumer.rb
+++ b/lib/deimos/active_record_consumer.rb
@@ -48,6 +48,12 @@ module Deimos
       def compacted(val)
         config[:compacted] = val
       end
+
+      # @param limit [Integer] Maximum number of transactions in a single database call.
+      # @return [void]
+      def max_db_batch_size(limit)
+        config[:max_db_batch_size] = limit
+      end
     end
 
     # Setup
@@ -62,6 +68,7 @@ module Deimos
       end
 
       @compacted = self.class.config[:compacted] != false
+      @max_db_batch_size = self.class.config[:max_db_batch_size]
     end
 
     # Override this method (with `super`) if you want to add/change the default

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -424,6 +424,9 @@ module Deimos
       # Configure the usage of generated schema classes for this consumer
       # @return [Boolean]
       setting :use_schema_classes
+      # Optional maximum limit for batching database calls to reduce the load on the db.
+      # @return [Integer]
+      setting :max_db_batch_size
 
       # These are the phobos "listener" configs. See CONFIGURATION.md for more
       # info.

--- a/spec/config/configuration_spec.rb
+++ b/spec/config/configuration_spec.rb
@@ -90,7 +90,8 @@ describe Deimos, 'configuration' do
           offset_retention_time: nil,
           heartbeat_interval: 10,
           handler: 'ConsumerTest::MyConsumer',
-          use_schema_classes: nil
+          use_schema_classes: nil,
+          max_db_batch_size: nil
         }, {
           topic: 'my_batch_consume_topic',
           group_id: 'my_batch_group_id',
@@ -107,7 +108,8 @@ describe Deimos, 'configuration' do
           offset_retention_time: nil,
           heartbeat_interval: 10,
           handler: 'ConsumerTest::MyBatchConsumer',
-          use_schema_classes: nil
+          use_schema_classes: nil,
+          max_db_batch_size: nil
         }
       ],
       producer: {
@@ -258,7 +260,8 @@ describe Deimos, 'configuration' do
             offset_retention_time: 13,
             heartbeat_interval: 13,
             handler: 'MyConfigConsumer',
-            use_schema_classes: false
+            use_schema_classes: false,
+            max_db_batch_size: nil
           }
         ],
         producer: {


### PR DESCRIPTION
## Description
When consuming many records it is possible to overwhelm the database based on the amount of records being upserted/removed. This change adds a new option `max_db_batch_size`, which can be used to limit the amount of transactions in a single database call.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
