### PR TITLE
CHP-1000: Add option to limit database queries to a maximum size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Feature: Limit amount of transactions in a single database call with `max_db_batch_size`
+
 # 1.19.0 - 2023-02-21
 
 - Feature: When consuming data in batch mode, this adds ability to save data to multiple tables with `association_list`.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -83,6 +83,7 @@ key_config|nil|Configuration hash for message keys. See [Kafka Message Keys](../
 disabled|false|Set to true to skip starting an actual listener for this consumer on startup.
 group_id|nil|ID of the consumer group.
 use_schema_classes|nil|Set to true or false to enable or disable using the consumers schema classes. See [Generated Schema Classes](../README.md#generated-schema-classes)
+max_db_batch_size|nil|Maximum limit for batching database calls to reduce the load on the db.
 max_concurrency|1|Number of threads created for this listener. Each thread will behave as an independent consumer. They don't share any state.
 start_from_beginning|true|Once the consumer group has checkpointed its progress in the topic's partitions, the consumers will always start from the checkpointed offsets, regardless of config. As such, this setting only applies when the consumer initially starts consuming from a topic
 max_bytes_per_partition|512.kilobytes|Maximum amount of data fetched from a single partition at a time.

--- a/lib/deimos/active_record_consume/batch_consumption.rb
+++ b/lib/deimos/active_record_consume/batch_consumption.rb
@@ -78,18 +78,19 @@ module Deimos
         # deleted record (no payload)
         removed, upserted = messages.partition(&:tombstone?)
 
+        max_db_batch_size = self.class.config[:max_db_batch_size]
         if upserted.any?
-          if @max_db_batch_size
-            upserted.each_slice(@max_db_batch_size) { |group| upsert_records(group) }
+          if max_db_batch_size
+            upserted.each_slice(max_db_batch_size) { |group| upsert_records(group) }
           else
             upsert_records(upserted)
           end
         end
 
-        return unless removed.any?
+        return if removed.empty?
 
-        if @max_db_batch_size
-          removed.each_slice(@max_db_batch_size) { |group| remove_records(group) }
+        if max_db_batch_size
+          removed.each_slice(max_db_batch_size) { |group| remove_records(group) }
         else
           remove_records(removed)
         end

--- a/lib/deimos/active_record_consumer.rb
+++ b/lib/deimos/active_record_consumer.rb
@@ -48,6 +48,12 @@ module Deimos
       def compacted(val)
         config[:compacted] = val
       end
+
+      # @param limit [Integer] Maximum number of transactions in a single database call.
+      # @return [void]
+      def max_db_batch_size(limit)
+        config[:max_db_batch_size] = limit
+      end
     end
 
     # Setup
@@ -62,6 +68,7 @@ module Deimos
       end
 
       @compacted = self.class.config[:compacted] != false
+      @max_db_batch_size = self.class.config[:max_db_batch_size]
     end
 
     # Override this method (with `super`) if you want to add/change the default

--- a/lib/deimos/active_record_consumer.rb
+++ b/lib/deimos/active_record_consumer.rb
@@ -68,7 +68,6 @@ module Deimos
       end
 
       @compacted = self.class.config[:compacted] != false
-      @max_db_batch_size = self.class.config[:max_db_batch_size]
     end
 
     # Override this method (with `super`) if you want to add/change the default

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -424,6 +424,9 @@ module Deimos
       # Configure the usage of generated schema classes for this consumer
       # @return [Boolean]
       setting :use_schema_classes
+      # Optional maximum limit for batching database calls to reduce the load on the db.
+      # @return [Integer]
+      setting :max_db_batch_size
 
       # These are the phobos "listener" configs. See CONFIGURATION.md for more
       # info.

--- a/spec/active_record_consume/batch_consumption_spec.rb
+++ b/spec/active_record_consume/batch_consumption_spec.rb
@@ -2,9 +2,7 @@
 
 RSpec.describe Deimos::ActiveRecordConsume::BatchConsumption do
   let(:batch_consumer) do
-    Class.new do
-      extend Deimos::ActiveRecordConsume::BatchConsumption
-    end
+    Deimos::ActiveRecordConsumer.new
   end
 
   describe '#update_database' do
@@ -19,37 +17,37 @@ RSpec.describe Deimos::ActiveRecordConsume::BatchConsumption do
         ]
       end
 
-      it 'should be called 1 time when record count < max batch size' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, records.count + 1)
-        expect(batch_consumer).to receive(:upsert_records).exactly(1)
+      it 'should be called 1 time when record size < max batch size' do
+        batch_consumer.class.config[:max_db_batch_size] = records.size + 1
+        expect(batch_consumer).to receive(:upsert_records).once
 
         batch_consumer.send(:update_database, records)
       end
 
-      it 'should be called 1 time when record count == max batch size' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, records.count)
-        expect(batch_consumer).to receive(:upsert_records).exactly(1)
+      it 'should be called 1 time when record size == max batch size' do
+        batch_consumer.class.config[:max_db_batch_size] = records.size
+        expect(batch_consumer).to receive(:upsert_records).once
 
         batch_consumer.send(:update_database, records)
       end
 
-      it 'should be called multiple times when record count > max batch size' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, records.size - 1)
-        expect(batch_consumer).to receive(:upsert_records).exactly(2)
+      it 'should be called multiple times when record size > max batch size' do
+        batch_consumer.class.config[:max_db_batch_size] = records.size - 1
+        expect(batch_consumer).to receive(:upsert_records).twice
 
         batch_consumer.send(:update_database, records)
       end
 
-      it 'should be called records.count times when max batch size is 1' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, 1)
+      it 'should be called records.size times when max batch size is 1' do
+        batch_consumer.class.config[:max_db_batch_size] = 1
         expect(batch_consumer).to receive(:upsert_records).exactly(records.size)
 
         batch_consumer.send(:update_database, records)
       end
 
       it 'should be called 1 time when batch size is nil' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, nil)
-        expect(batch_consumer).to receive(:upsert_records).exactly(1)
+        batch_consumer.class.config[:max_db_batch_size] = nil
+        expect(batch_consumer).to receive(:upsert_records).once
 
         batch_consumer.send(:update_database, records)
       end
@@ -66,37 +64,37 @@ RSpec.describe Deimos::ActiveRecordConsume::BatchConsumption do
         ]
       end
 
-      it 'should be called 1 time when record count < max batch size' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, records.count + 1)
-        expect(batch_consumer).to receive(:remove_records).exactly(1)
+      it 'should be called 1 time when record size < max batch size' do
+        batch_consumer.class.config[:max_db_batch_size] = records.size + 1
+        expect(batch_consumer).to receive(:remove_records).once
 
         batch_consumer.send(:update_database, records)
       end
 
-      it 'should be called 1 time when record count == max batch size' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, records.count)
-        expect(batch_consumer).to receive(:remove_records).exactly(1)
+      it 'should be called 1 time when record size == max batch size' do
+        batch_consumer.class.config[:max_db_batch_size] = records.size
+        expect(batch_consumer).to receive(:remove_records).once
 
         batch_consumer.send(:update_database, records)
       end
 
-      it 'should be called multiple times when record count > max batch size' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, records.size - 1)
-        expect(batch_consumer).to receive(:remove_records).exactly(2)
+      it 'should be called multiple times when record size > max batch size' do
+        batch_consumer.class.config[:max_db_batch_size] = records.size - 1
+        expect(batch_consumer).to receive(:remove_records).twice
 
         batch_consumer.send(:update_database, records)
       end
 
-      it 'should be called record.count times when max batch size is 1' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, 1)
+      it 'should be called record.size times when max batch size is 1' do
+        batch_consumer.class.config[:max_db_batch_size] = 1
         expect(batch_consumer).to receive(:remove_records).exactly(records.size)
 
         batch_consumer.send(:update_database, records)
       end
 
       it 'should be called 1 time when batch size is nil' do
-        batch_consumer.instance_variable_set(:@max_db_batch_size, nil)
-        expect(batch_consumer).to receive(:remove_records).exactly(1)
+        batch_consumer.class.config[:max_db_batch_size] = nil
+        expect(batch_consumer).to receive(:remove_records).once
 
         batch_consumer.send(:update_database, records)
       end

--- a/spec/active_record_consume/batch_consumption_spec.rb
+++ b/spec/active_record_consume/batch_consumption_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe Deimos::ActiveRecordConsume::BatchConsumption do
+  let(:batch_consumer) do
+    Class.new do
+      extend Deimos::ActiveRecordConsume::BatchConsumption
+    end
+  end
+
+  describe '#update_database' do
+    describe 'upsert_records' do
+      let(:records) do
+        [
+          Deimos::Message.new({ v: 1 }, nil, key: 1),
+          Deimos::Message.new({ v: 2 }, nil, key: 2),
+          Deimos::Message.new({ v: 3 }, nil, key: 3),
+          Deimos::Message.new({ v: 4 }, nil, key: 4),
+          Deimos::Message.new({ v: 5 }, nil, key: 5)
+        ]
+      end
+
+      it 'should be called 1 time when record count < max batch size' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, records.count + 1)
+        expect(batch_consumer).to receive(:upsert_records).exactly(1)
+
+        batch_consumer.send(:update_database, records)
+      end
+
+      it 'should be called 1 time when record count == max batch size' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, records.count)
+        expect(batch_consumer).to receive(:upsert_records).exactly(1)
+
+        batch_consumer.send(:update_database, records)
+      end
+
+      it 'should be called multiple times when record count > max batch size' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, records.size - 1)
+        expect(batch_consumer).to receive(:upsert_records).exactly(2)
+
+        batch_consumer.send(:update_database, records)
+      end
+
+      it 'should be called records.count times when max batch size is 1' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, 1)
+        expect(batch_consumer).to receive(:upsert_records).exactly(records.size)
+
+        batch_consumer.send(:update_database, records)
+      end
+
+      it 'should be called 1 time when batch size is nil' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, nil)
+        expect(batch_consumer).to receive(:upsert_records).exactly(1)
+
+        batch_consumer.send(:update_database, records)
+      end
+    end
+
+    describe 'remove_records' do
+      let(:records) do
+        [
+          Deimos::Message.new(nil, nil, key: 1),
+          Deimos::Message.new(nil, nil, key: 2),
+          Deimos::Message.new(nil, nil, key: 3),
+          Deimos::Message.new(nil, nil, key: 4),
+          Deimos::Message.new(nil, nil, key: 5)
+        ]
+      end
+
+      it 'should be called 1 time when record count < max batch size' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, records.count + 1)
+        expect(batch_consumer).to receive(:remove_records).exactly(1)
+
+        batch_consumer.send(:update_database, records)
+      end
+
+      it 'should be called 1 time when record count == max batch size' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, records.count)
+        expect(batch_consumer).to receive(:remove_records).exactly(1)
+
+        batch_consumer.send(:update_database, records)
+      end
+
+      it 'should be called multiple times when record count > max batch size' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, records.size - 1)
+        expect(batch_consumer).to receive(:remove_records).exactly(2)
+
+        batch_consumer.send(:update_database, records)
+      end
+
+      it 'should be called record.count times when max batch size is 1' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, 1)
+        expect(batch_consumer).to receive(:remove_records).exactly(records.size)
+
+        batch_consumer.send(:update_database, records)
+      end
+
+      it 'should be called 1 time when batch size is nil' do
+        batch_consumer.instance_variable_set(:@max_db_batch_size, nil)
+        expect(batch_consumer).to receive(:remove_records).exactly(1)
+
+        batch_consumer.send(:update_database, records)
+      end
+    end
+  end
+end

--- a/spec/config/configuration_spec.rb
+++ b/spec/config/configuration_spec.rb
@@ -90,7 +90,8 @@ describe Deimos, 'configuration' do
           offset_retention_time: nil,
           heartbeat_interval: 10,
           handler: 'ConsumerTest::MyConsumer',
-          use_schema_classes: nil
+          use_schema_classes: nil,
+          max_db_batch_size: nil
         }, {
           topic: 'my_batch_consume_topic',
           group_id: 'my_batch_group_id',
@@ -107,7 +108,8 @@ describe Deimos, 'configuration' do
           offset_retention_time: nil,
           heartbeat_interval: 10,
           handler: 'ConsumerTest::MyBatchConsumer',
-          use_schema_classes: nil
+          use_schema_classes: nil,
+          max_db_batch_size: nil
         }
       ],
       producer: {
@@ -258,7 +260,8 @@ describe Deimos, 'configuration' do
             offset_retention_time: 13,
             heartbeat_interval: 13,
             handler: 'MyConfigConsumer',
-            use_schema_classes: false
+            use_schema_classes: false,
+            max_db_batch_size: nil
           }
         ],
         producer: {


### PR DESCRIPTION
## Description

When consuming many records it is possible to overwhelm the database based on the amount of records being upserted/removed. This change adds a new option `max_db_batch_size`, which can be used to limit the amount of transactions in a single database call.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Integrated with local project
- [ ] Added unit tests to test new functionality

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
