### PR TITLE
set rubocop block aligment to start-of-line

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,7 @@ Layout/AccessModifierIndentation:
 #     baz
 #   end
 Layout/BlockAlignment:
-  EnforcedStyleAlignWith: start_of_block
+  EnforcedStyleAlignWith: start_of_line
 
 # something.
 #  method

--- a/lib/deimos/active_record_consume/batch_consumption.rb
+++ b/lib/deimos/active_record_consume/batch_consumption.rb
@@ -159,7 +159,7 @@ module Deimos
 
             columns = key_columns(nil, assoc.klass)
             save_records_to_database(assoc.klass, columns, sub_records) if sub_records.any?
-          end
+        end
       end
 
       # Delete any records with a tombstone.

--- a/lib/deimos/backends/base.rb
+++ b/lib/deimos/backends/base.rb
@@ -44,7 +44,7 @@ module Deimos
                   payload: message.payload,
                   key: message.key
                 }
-              end
+                        end
             )
           end
 

--- a/lib/deimos/utils/inline_consumer.rb
+++ b/lib/deimos/utils/inline_consumer.rb
@@ -133,12 +133,12 @@ module Deimos
         subscribers << ActiveSupport::Notifications.
           subscribe('phobos.listener.process_message') do
             frk_consumer.last_message_time = Time.zone.now
-          end
+        end
         subscribers << ActiveSupport::Notifications.
           subscribe('phobos.listener.start_handler') do
             frk_consumer.start_time = Time.zone.now
             frk_consumer.last_message_time = nil
-          end
+        end
         subscribers << ActiveSupport::Notifications.
           subscribe('heartbeat.consumer.kafka') do
             if frk_consumer.last_message_time
@@ -149,7 +149,7 @@ module Deimos
               Deimos.config.logger.error('Aborting - initial wait too long')
               raise Phobos::AbortError
             end
-          end
+        end
         listener.start
         subscribers.each { |s| ActiveSupport::Notifications.unsubscribe(s) }
       end

--- a/spec/active_record_batch_consumer_mysql_spec.rb
+++ b/spec/active_record_batch_consumer_mysql_spec.rb
@@ -240,5 +240,5 @@ module ActiveRecordBatchConsumerTest
         expect(Widget.first.id).to eq(Locale.second.widget_id)
       end
     end
-           end
+  end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -36,7 +36,7 @@ module ConsumerTest
                                  'some_int' => 123 }) do |payload, _metadata|
                                    expect(payload['test_id']).to eq('foo')
                                    expect(payload['some_int']).to eq(123)
-                                 end
+            end
           end
 
           it 'should consume a nil message' do
@@ -55,11 +55,11 @@ module ConsumerTest
             MyConsumer.new.around_consume({ 'test_id' => 'foo',
                                             'some_int' => 123 }, test_metadata) do |_payload, metadata|
                                               expect(metadata[:key]).to eq('foo')
-                                            end
+            end
             MyConsumer.new.around_consume({ 'test_id' => 'foo',
                                             'some_int' => 123 }, test_metadata) do |_payload, metadata|
                                               expect(metadata[:key]).to eq('foo')
-                                            end
+            end
           end
 
           it 'should consume a message on a topic' do
@@ -68,7 +68,7 @@ module ConsumerTest
                                  'some_int' => 123 }) do |payload, _metadata|
                                    expect(payload['test_id']).to eq('foo')
                                    expect(payload['some_int']).to eq(123)
-                                 end
+            end
           end
 
           it 'should fail on invalid message' do
@@ -194,7 +194,7 @@ module ConsumerTest
                              'updated_at' => Time.now.to_i,
                              'timestamp' => 2.minutes.ago.to_s }) do |payload, _metadata|
                                expect(payload['test_id']).to eq('foo')
-                             end
+        end
       end
 
       it 'should fail nicely when timestamp wrong format' do
@@ -205,14 +205,14 @@ module ConsumerTest
                              'updated_at' => Time.now.to_i,
                              'timestamp' => 'dffdf' }) do |payload, _metadata|
                                expect(payload['test_id']).to eq('foo')
-                             end
+        end
         test_consume_message('my_consume_topic',
                              { 'test_id' => 'foo',
                              'some_int' => 123,
                              'updated_at' => Time.now.to_i,
                              'timestamp' => '' }) do |payload, _metadata|
                                expect(payload['test_id']).to eq('foo')
-                             end
+        end
       end
 
     end

--- a/spec/utils/db_poller_spec.rb
+++ b/spec/utils/db_poller_spec.rb
@@ -261,7 +261,7 @@ each_db_config(Deimos::Utils::DbPoller::Base) do
             m.call(*args)
             expect(info.reload.last_sent.in_time_zone).to eq(time_value(mins: -61, secs: 32))
             expect(info.last_sent_id).to eq(widgets[1].id)
-          end
+        end
         expect(poller).to receive(:process_and_touch_info).ordered.
           with([widgets[2], widgets[3], widgets[4]], anything).and_call_original
         expect(poller).to receive(:process_and_touch_info).ordered.


### PR DESCRIPTION
# Pull Request Template

## Description
Enforcing BlockAlignment "start-of-block" end up moving some `end` keywords to a weird position if the starting statement is split into multiple lines.

Fixes # (issue)
https://github.com/flipp-oss/deimos/issues/183

## Type of change
Coding style




## How Has This Been Tested?
No functional changes. Unit test is sufficient.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
