### PR TITLE
Don't update last_sent to current time on every poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Fix: Don't update last_sent to current time on every poll.
+
 # 1.22.2 - 2023-05-10
 - Feature: Add `DEIMOS_TASK_NAME` env variable when running a task (consumer, DB poller, DB producer).
 

--- a/lib/deimos/utils/db_poller/state_based.rb
+++ b/lib/deimos/utils/db_poller/state_based.rb
@@ -12,20 +12,23 @@ module Deimos
         def process_updates
           Deimos.config.logger.info("Polling #{log_identifier}")
           status = PollStatus.new(0, 0, 0)
+          first_batch = true
 
           # poll_query gets all the relevant data from the database, as defined
           # by the producer itself.
           loop do
             Deimos.config.logger.debug("Polling #{log_identifier}, batch #{status.current_batch}")
             batch = fetch_results.to_a
-            if batch.empty?
-              @info.touch(:last_sent)
-              break
-            end
+            break if batch.empty?
 
+            first_batch = false
             success = process_batch_with_span(batch, status)
             finalize_batch(batch, success)
           end
+
+          # If there were no results at all, we update last_sent so that we still get a wait
+          # before the next poll.
+          @info.touch(:last_sent) if first_batch
           Deimos.config.logger.info("Poll #{log_identifier} complete (#{status.report}")
         end
 

--- a/spec/utils/db_poller_spec.rb
+++ b/spec/utils/db_poller_spec.rb
@@ -324,13 +324,18 @@ each_db_config(Deimos::Utils::DbPoller::Base) do
         poller.process_updates
         poller.process_updates
 
-        expect(MyProducer).to have_received(:poll_query).twice.
+        expect(MyProducer).to have_received(:poll_query).
           with(time_from: time_value(secs: -1),
                time_to: time_value(secs: 120), # plus 122 seconds minus 2 seconds
                column_name: :updated_at,
                min_id: last_widget.id)
+        expect(MyProducer).to have_received(:poll_query).
+          with(time_from: time_value(secs: 122),
+               time_to: time_value(secs: 120), # yes this is weird but it's because of travel_to
+               column_name: :updated_at,
+               min_id: last_widget.id)
         expect(Deimos.config.logger).to have_received(:info).
-          with('Poll my-topic-with-id complete at 2015-05-05 00:59:58 -0400 (3 batches, 0 errored batches, 7 processed messages)')
+          with('Poll MyProducer: ["my-topic-with-id"] complete at 2015-05-05 00:59:58 -0400 (3 batches, 0 errored batches, 7 processed messages)')
       end
 
       it 'should update PollInfo timestamp after processing' do
@@ -382,7 +387,7 @@ each_db_config(Deimos::Utils::DbPoller::Base) do
           expect(info.last_sent.in_time_zone).to eq(time_value(mins: -61, secs: 30))
           expect(info.last_sent_id).to eq(widgets[6].id)
           expect(Deimos.config.logger).to have_received(:info).
-            with('Poll my-topic-with-id complete at 2015-05-05 00:59:58 -0400 (2 batches, 1 errored batches, 7 processed messages)')
+            with('Poll MyProducer: ["my-topic-with-id"] complete at 2015-05-05 00:59:58 -0400 (2 batches, 1 errored batches, 7 processed messages)')
         end
       end
     end


### PR DESCRIPTION
This is a bug in the DB poller which can be described as follows:

* Message X comes in at timestamp 2.
* LOTS of messages come in at timestamp 2.
* DB poller takes 5 timestamps to process, so it’s now timestamp 7 when all the timestamp 2 messages are processed.
* While processing a batch with message X, another process updates the updated_at timestamp for message X with timestamp 6.
* Deimos updates last_sent to be timestamp 7.
* All messages with timestamp 6 are missed.

This bug was introduced with [this PR](https://github.com/flipp-oss/deimos/pull/169) - the idea was to ensure a 60-second wait if there were no messages to process - instead, it made it so *every* set of batches would end up with a last_sent time of the current time, since the last batch in the set is always empty.