### PR TITLE
Fix use_schema_classes bug

### DIFF
--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -86,7 +86,7 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       schema(kafka_config.schema) if kafka_config.schema.present?
       namespace(kafka_config.namespace) if kafka_config.namespace.present?
       key_config(**kafka_config.key_config) if kafka_config.key_config.present?
-      schema_class_config(kafka_config.use_schema_classes) if kafka_config.use_schema_classes.present?
+      schema_class_config(kafka_config.use_schema_classes)
       if kafka_config.respond_to?(:bulk_import_id_column) # consumer
         klass.config.merge!(
           bulk_import_id_column: kafka_config.bulk_import_id_column,

--- a/lib/deimos/utils/schema_class.rb
+++ b/lib/deimos/utils/schema_class.rb
@@ -35,8 +35,7 @@ module Deimos
         # @param config [Hash] Producer or Consumer config
         # @return [Boolean]
         def use?(config)
-          use_schema_classes = config[:use_schema_classes]
-          use_schema_classes.present? ? use_schema_classes : Deimos.config.schema.use_schema_classes
+          config.has_key?(:use_schema_classes) ? config[:use_schema_classes] : Deimos.config.schema.use_schema_classes
         end
 
       end


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Deimos's feature `use_schema_classes` was not working because this field was not populated as part of the producer/consumer config and there was a wrong logic in evaluating this field. Fixed the bug so that `use_schema_classes` can be used.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Tested alongside with https://github.com/wishabi/item-platform/pull/231 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
