### PR TITLE
#195 Fix buffer overflow exception handling

### DIFF
--- a/lib/deimos/kafka_message.rb
+++ b/lib/deimos/kafka_message.rb
@@ -39,11 +39,12 @@ module Deimos
     def self.decoded(messages=[])
       return [] if messages.empty?
 
-      decoder = self.decoder(messages.first.topic)&.new
+      decoder_class = self.decoder(messages.first.topic)
+      decoder = decoder_class&.new
       messages.map do |m|
         {
           key: m.key.present? ? decoder&.decode_key(m.key) || m.key : nil,
-          payload: decoder&.decoder&.decode(m.message) || m.message
+          payload: decoder_class&.decoder&.decode(m.message) || m.message
         }
       end
     end


### PR DESCRIPTION
## Description
`@logger.error(Deimos::KafkaMessage.decoded(messages))` in the rescue block fails to decode the message and causes wrong exception raised
This PR:
- fixes message decoding
- adds rescue block around decoding call to make sure if decode is misconfigured that does not interfere with original exception

Fixes #195

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
tests added

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
