### PR TITLE
post_process method outside batch consumption DB transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 - Fix: Fixed handler metric for status:received, status:success in batch consumption
+- Feature: Adds post_process method for BatchConsumers to use the ActiveRecord objects after saving records to DB.
 
 # 1.22.5 - 2023-07-18
 - Fix: Fixed buffer overflow crash with DB producer.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,11 @@ class MyBatchConsumer < Deimos::Consumer
       # Do something 
     end
   end
+
+  def post_process(records)
+    # ActiveRecord objects that have been used to save to the database.
+    # They contain primary keys only if associations are involved.
+  end
 end
 ```
 #### Saving data to Multiple Database tables

--- a/lib/deimos/active_record_consume/mass_updater.rb
+++ b/lib/deimos/active_record_consume/mass_updater.rb
@@ -85,6 +85,7 @@ module Deimos
       def mass_update(record_list)
         save_records_to_database(record_list)
         import_associations(record_list) if record_list.associations.any?
+        record_list.records
       end
 
     end

--- a/spec/active_record_consume/batch_consumption_spec.rb
+++ b/spec/active_record_consume/batch_consumption_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe Deimos::ActiveRecordConsume::BatchConsumption do
       it 'should be called 1 time when record size == max batch size' do
         batch_consumer.class.config[:max_db_batch_size] = records.size
         expect(batch_consumer).to receive(:upsert_records).once
-
         batch_consumer.send(:update_database, records)
       end
 
@@ -97,6 +96,26 @@ RSpec.describe Deimos::ActiveRecordConsume::BatchConsumption do
         expect(batch_consumer).to receive(:remove_records).once
 
         batch_consumer.send(:update_database, records)
+      end
+    end
+  end
+
+  describe '#consume_batch' do
+    describe 'post_process in compact mode' do
+      let(:payload) do
+        [
+          { v: 1 }, { v: 2 }, { v: 3 }, { v: 4 }, { v: 5 }
+        ]
+      end
+      let(:metadata) do
+        { keys: [1, 2, 3, 4, 5] }
+      end
+
+      it 'should be called once with a flat array of records' do
+        records = [Object, Object] # should be ActiveRecord object
+        expect(batch_consumer).to receive(:post_process).once.with(records)
+        expect(batch_consumer).to receive(:update_database) { records }
+        batch_consumer.send(:consume_batch, payload, metadata)
       end
     end
   end


### PR DESCRIPTION
# Pull Request Template

## Description

After batch consumption transaction is complete(BULK INSERTs), previously nothing is returned. Now we are passing the active record objects created back to consume_batch method so these records objects can be used by `post_process` hook method. Consumers can override this to do an action on the Active Record Models.

Note that these active record models are used by ActiveRecord-Import gem to bulk insert data. So record IDs are populated only if there is association involved.

Usecase: After saving records to Database, I queue a sidekiq job with record IDs.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I ran the unit tests locally and this code change adds an empty `post_process` method in consumer. So it should not hurt any one upgrading to this version. For a meaningful use, they will have to override `post_process` in their consumers.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added an RSpec to note that the records are passed to post_process method
- [ ] Couldnot add an RSpec to try both the branches of compacted and uncompacted messages. But I tried it locally by setting the parameter on consumer class.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
