### PR TITLE
CCOL-2039: Global consumer configurations for replace_association & bulk_id_generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 - Fix: Fixed handler metric for status:received, status:success in batch consumption
 - Feature: Allow pre processing of messages prior to bulk consumption
+- Feature: Add global configuration for custom `bulk_import_id_generator` proc for all consumers
+- Feature: Add individual configuration for custom `bulk_import_id_generator` proc per consumer
+- Feature: Add global `replace_assocations` value for  for all consumers
+- Feature: Add individual `replace_assocations` value for for individual consumers
 
 # 1.22.5 - 2023-07-18
 - Fix: Fixed buffer overflow crash with DB producer.

--- a/lib/deimos/active_record_consume/batch_consumption.rb
+++ b/lib/deimos/active_record_consume/batch_consumption.rb
@@ -198,7 +198,8 @@ module Deimos
 
           BatchRecord.new(klass: @klass,
                           attributes: attrs,
-                          bulk_import_column: col)
+                          bulk_import_column: col,
+                          bulk_import_id_generator: self.class.bulk_import_id_generator)
         end
         BatchRecordList.new(records.compact)
       end

--- a/lib/deimos/active_record_consume/batch_consumption.rb
+++ b/lib/deimos/active_record_consume/batch_consumption.rb
@@ -165,7 +165,8 @@ module Deimos
         updater = MassUpdater.new(@klass,
                                   key_col_proc: key_col_proc,
                                   col_proc: col_proc,
-                                  replace_associations: self.class.config[:replace_associations])
+                                  replace_associations: self.class.replace_associations,
+                                  bulk_import_id_generator: self.class.bulk_import_id_generator)
         updater.mass_update(record_list)
       end
 

--- a/lib/deimos/active_record_consume/batch_record.rb
+++ b/lib/deimos/active_record_consume/batch_record.rb
@@ -17,16 +17,17 @@ module Deimos
       # @return [String] The column name to use for bulk IDs - defaults to `bulk_import_id`.
       attr_accessor :bulk_import_column
 
-      delegate :valid?, to: :record
+      delegate :valid?, :errors, :send, :attributes, to: :record
 
       # @param klass [Class < ActiveRecord::Base]
       # @param attributes [Hash] the full attribute list, including associations.
       # @param bulk_import_column [String]
-      def initialize(klass:, attributes:, bulk_import_column: nil)
+      # @param bulk_import_id_generator [Proc]
+      def initialize(klass:, attributes:, bulk_import_column: nil, bulk_import_id_generator: nil)
         @klass = klass
         if bulk_import_column
           self.bulk_import_column = bulk_import_column
-          self.bulk_import_id = SecureRandom.uuid
+          self.bulk_import_id = bulk_import_id_generator&.call
           attributes[bulk_import_column] = bulk_import_id
         end
         attributes = attributes.with_indifferent_access
@@ -43,7 +44,7 @@ module Deimos
         return if @klass.column_names.include?(self.bulk_import_column.to_s)
 
         raise "Create bulk_import_id on the #{@klass.table_name} table." \
-              ' Run rails g deimos:bulk_import_id {table} to create the migration.'
+                ' Run rails g deimos:bulk_import_id {table} to create the migration.'
       end
 
       # @return [Class < ActiveRecord::Base]

--- a/lib/deimos/active_record_consume/mass_updater.rb
+++ b/lib/deimos/active_record_consume/mass_updater.rb
@@ -22,7 +22,7 @@ module Deimos
       def initialize(klass, key_col_proc: nil, col_proc: nil, replace_associations: true, bulk_import_id_generator: nil)
         @klass = klass
         @replace_associations = replace_associations
-        @bulk_import_id_generator = bulk_import_id_generator || proc { SecureRandom.uuid }
+        @bulk_import_id_generator = bulk_import_id_generator
 
         @key_cols = {}
         @key_col_proc = key_col_proc
@@ -70,7 +70,7 @@ module Deimos
       def import_associations(record_list)
         record_list.fill_primary_keys!
 
-        import_id = @replace_associations ? @bulk_import_id_generator.call : nil
+        import_id = @replace_associations ? @bulk_import_id_generator&.call : nil
         record_list.associations.each do |assoc|
           sub_records = record_list.map { |r| r.sub_records(assoc.name, import_id) }.flatten
           next unless sub_records.any?

--- a/lib/deimos/active_record_consume/mass_updater.rb
+++ b/lib/deimos/active_record_consume/mass_updater.rb
@@ -19,9 +19,10 @@ module Deimos
       # @param key_col_proc [Proc<Class < ActiveRecord::Base>]
       # @param col_proc [Proc<Class < ActiveRecord::Base>]
       # @param replace_associations [Boolean]
-      def initialize(klass, key_col_proc: nil, col_proc: nil, replace_associations: true)
+      def initialize(klass, key_col_proc: nil, col_proc: nil, replace_associations: true, bulk_import_id_generator: nil)
         @klass = klass
         @replace_associations = replace_associations
+        @bulk_import_id_generator = bulk_import_id_generator || proc { SecureRandom.uuid }
 
         @key_cols = {}
         @key_col_proc = key_col_proc
@@ -69,7 +70,7 @@ module Deimos
       def import_associations(record_list)
         record_list.fill_primary_keys!
 
-        import_id = @replace_associations ? SecureRandom.uuid : nil
+        import_id = @replace_associations ? @bulk_import_id_generator.call : nil
         record_list.associations.each do |assoc|
           sub_records = record_list.map { |r| r.sub_records(assoc.name, import_id) }.flatten
           next unless sub_records.any?

--- a/lib/deimos/active_record_consumer.rb
+++ b/lib/deimos/active_record_consumer.rb
@@ -35,6 +35,16 @@ module Deimos
         config[:bulk_import_id_column]
       end
 
+      # @return [Proc]
+      def bulk_import_id_generator
+        config[:bulk_import_id_generator]
+      end
+
+      # @return [Boolean]
+      def replace_associations
+        config[:replace_associations]
+      end
+
       # @param val [Boolean] Turn pre-compaction of the batch on or off. If true,
       # only the last message for each unique key in a batch is processed.
       # @return [void]

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -79,6 +79,7 @@ module Deimos # rubocop:disable Metrics/ModuleLength
 
   # @!visibility private
   # @param kafka_config [FigTree::ConfigStruct]
+  # rubocop:disable  Metrics/PerceivedComplexity, Metrics/AbcSize
   def self.configure_producer_or_consumer(kafka_config)
     klass = kafka_config.class_name.constantize
     klass.class_eval do
@@ -90,11 +91,18 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       if kafka_config.respond_to?(:bulk_import_id_column) # consumer
         klass.config.merge!(
           bulk_import_id_column: kafka_config.bulk_import_id_column,
-          replace_associations: kafka_config.replace_associations
+          replace_associations: if kafka_config.replace_associations.nil?
+                                  Deimos.config.consumers.replace_associations
+                                else
+                                  kafka_config.replace_associations
+                                end,
+          bulk_import_id_generator: kafka_config.bulk_import_id_generator ||
+            Deimos.config.consumers.bulk_import_id_generator
         )
       end
     end
   end
+  # rubocop:enable Metrics/PerceivedComplexity, Metrics/AbcSize
 
   define_settings do
 
@@ -242,6 +250,15 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       # Not needed if reraise_errors is set to true.
       # @return [Block]
       setting(:fatal_error, proc { false })
+
+      # The default function to generate a bulk ID for bulk consumers
+      # @return [Block]
+      setting(:bulk_import_id_generator, proc { SecureRandom.uuid })
+
+      # If true, multi-table consumers will blow away associations rather than appending to them.
+      # Applies to all consumers unless specified otherwise
+      # @return [Boolean]
+      setting :replace_associations, true
     end
 
     setting :producers do
@@ -445,7 +462,13 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       setting :bulk_import_id_column, :bulk_import_id
       # If true, multi-table consumers will blow away associations rather than appending to them.
       # @return [Boolean]
-      setting :replace_associations, true
+      setting :replace_associations, nil
+
+      # The default function to generate a bulk ID for this consumer
+      # Uses the consumers proc defined in the consumers config by default unless
+      # specified for individual consumers
+      # @return [Block]
+      setting :bulk_import_id_generator, nil
 
       # These are the phobos "listener" configs. See CONFIGURATION.md for more
       # info.

--- a/spec/active_record_consume/mass_updater_spec.rb
+++ b/spec/active_record_consume/mass_updater_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe Deimos::ActiveRecordConsume::MassUpdater do
       end
     end
 
+    let(:bulk_id_generator) { proc { SecureRandom.uuid } }
+
     before(:each) do
       stub_const('Widget', widget_class)
       stub_const('Detail', detail_class)
@@ -52,20 +54,24 @@ RSpec.describe Deimos::ActiveRecordConsume::MassUpdater do
             Deimos::ActiveRecordConsume::BatchRecord.new(
               klass: Widget,
               attributes: { test_id: 'id1', some_int: 5, detail: { title: 'Title 1' } },
-              bulk_import_column: 'bulk_import_id'
+              bulk_import_column: 'bulk_import_id',
+              bulk_import_id_generator: bulk_id_generator
             ),
             Deimos::ActiveRecordConsume::BatchRecord.new(
               klass: Widget,
               attributes: { test_id: 'id2', some_int: 10, detail: { title: 'Title 2' } },
-              bulk_import_column: 'bulk_import_id'
+              bulk_import_column: 'bulk_import_id',
+              bulk_import_id_generator: bulk_id_generator
             )
           ]
         )
       end
 
       it 'should mass update the batch' do
+        allow(SecureRandom).to receive(:uuid).and_return('1', '2')
         described_class.new(Widget).mass_update(batch)
         expect(Widget.count).to eq(2)
+        expect(Widget.all.to_a.map(&:bulk_import_id)).to match(%w(1 2))
         expect(Detail.count).to eq(2)
         expect(Widget.first.detail).not_to be_nil
         expect(Widget.last.detail).not_to be_nil

--- a/spec/active_record_consume/mass_updater_spec.rb
+++ b/spec/active_record_consume/mass_updater_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Deimos::ActiveRecordConsume::MassUpdater do
 
       it 'should mass update the batch' do
         allow(SecureRandom).to receive(:uuid).and_return('1', '2')
-        described_class.new(Widget).mass_update(batch)
+        described_class.new(Widget, bulk_import_id_generator: bulk_id_generator).mass_update(batch)
         expect(Widget.count).to eq(2)
         expect(Widget.all.to_a.map(&:bulk_import_id)).to match(%w(1 2))
         expect(Detail.count).to eq(2)


### PR DESCRIPTION
# Pull Request Template

## Description

1. Allow global and individual consumer batch id generator procs to be passed in for use in bulk imports
2. Allow global and individual consumer replace_associations configuration for use in bulk imports

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
