### PR TITLE
Option to skip large messages on DB poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Feature: Add configuration to skip messages that are too large to publish via DB poller.
+
 # 1.23.2 - 2024-01-22
 - Fix: Send a `publish_error` metric for errors other than `DeliveryFailed`.
 

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -500,6 +500,9 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       # The number of times to retry production when encountering a *non-Kafka* error. Set to nil
       # for infinite retries.
       setting :retries, 1
+      # If true, rather than shutting down when finding a message that is too large, log an
+      # error and skip it.
+      setting :skip_too_large_messages, false
       # Amount of time, in seconds, to wait before catching updates, to allow transactions
       # to complete but still pick up the right records. Should only be set for time-based mode.
       setting :delay_time, 2

--- a/lib/deimos/utils/db_poller/base.rb
+++ b/lib/deimos/utils/db_poller/base.rb
@@ -105,6 +105,25 @@ module Deimos
           raise Deimos::MissingImplementationError
         end
 
+        # @param exception [Exception]
+        # @param batch [Array<ActiveRecord::Base>]
+        # @param status [PollStatus]
+        # @param span [Object]
+        # @return [Boolean]
+        def handle_message_too_large(exception, batch, status, span)
+          Deimos.config.logger.error("Error publishing through DB Poller: #{exception.message}")
+          if @config.skip_too_large_messages
+            Deimos.config.logger.error("Skipping messages #{batch.map(&:id).join(', ')} since they are too large")
+            Deimos.config.tracer&.set_error(span, exception)
+            status.batches_errored += 1
+            true
+          else # do the same thing as regular Kafka::Error
+            sleep(0.5)
+            false
+          end
+        end
+
+        # rubocop:disable Metrics/AbcSize
         # @param batch [Array<ActiveRecord::Base>]
         # @param status [PollStatus]
         # @return [Boolean]
@@ -120,16 +139,7 @@ module Deimos
             status.batches_processed += 1
           rescue Kafka::BufferOverflow, Kafka::MessageSizeTooLarge,
                  Kafka::RecordListTooLarge => e
-            Deimos.config.logger.error("Error publishing through DB Poller: #{e.message}")
-            if @config.skip_too_large_messages
-              Deimos.config.logger.error("Skipping messages #{batch.map(&:id).join(', ')} since they are too large")
-              Deimos.config.tracer&.set_error(span, e)
-              status.batches_errored += 1
-              return false
-            else # do the same thing as regular Kafka::Error
-              sleep(0.5)
-              retry
-            end
+            retry unless handle_message_too_large(e, batch, status, span)
           rescue Kafka::Error => e # keep trying till it fixes itself
             Deimos.config.logger.error("Error publishing through DB Poller: #{e.message}")
             sleep(0.5)
@@ -151,6 +161,7 @@ module Deimos
           end
           true
         end
+        # rubocop:enable Metrics/AbcSize
 
         # Publish batch using the configured producers
         # @param batch [Array<ActiveRecord::Base>]


### PR DESCRIPTION
Currently, when DB Poller is unable to publish messages because they're too large for the broker, the poller will retry forever. This might be "correct" if we need some kind of alert / manual fix for the data. But in most cases, we'll want to just log an error and metric and move on.

This PR adds a configuration so we can make that happen.