### PR TITLE
CCOL-2441: Allow custom publishing batch size per producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-- Feature: Enable `producers.persistent_connections` phobos setting
->>>>>>> 3ea5999 (Allow on per producer level)
 - Feature: Added `max_batch_size` config to producer to allow custom batch size for publishing.
-=======
-- Feature: Added `max_batch_size` config to allow custom batch size for publishing per producer.
->>>>>>> 4806c5b (Allow on per producer level)
 
 # 1.24.3 - 2024-05-13
 - Feature: Enable `producers.persistent_connections` phobos setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
+<<<<<<< HEAD
+=======
+<<<<<<< HEAD
+- Feature: Enable `producers.persistent_connections` phobos setting
+>>>>>>> 3ea5999 (Allow on per producer level)
 - Feature: Added `max_batch_size` config to producer to allow custom batch size for publishing.
+=======
+- Feature: Added `max_batch_size` config to allow custom batch size for publishing per producer.
+>>>>>>> 4806c5b (Allow on per producer level)
 
 # 1.24.3 - 2024-05-13
 - Feature: Enable `producers.persistent_connections` phobos setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
+- Feature: Added `max_batch_size` config to producer to allow custom batch size for publishing.
 
 # 1.24.3 - 2024-05-13
-
 - Feature: Enable `producers.persistent_connections` phobos setting
 - Feature: Add consumer configuration, `save_associations_first` to save associated records of primary class prior to upserting primary records. Foreign key of associated records are assigned to the record class prior to saving the record class
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,7 +46,6 @@ schema|nil|Name of the schema to use to encode data before producing.
 namespace|nil|Namespace of the schema to use when finding it locally.
 key_config|nil|Configuration hash for message keys. See [Kafka Message Keys](../README.md#installation)
 use_schema_classes|nil|Set to true or false to enable or disable using the producers schema classes. See [Generated Schema Classes](../README.md#generated-schema-classes)
-max_batch_size|500|Maximum publishing batch size. Defaults to top-level configuration of 500.
 
 
 ## Defining Consumers

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -47,7 +47,6 @@ namespace|nil|Namespace of the schema to use when finding it locally.
 key_config|nil|Configuration hash for message keys. See [Kafka Message Keys](../README.md#installation)
 use_schema_classes|nil|Set to true or false to enable or disable using the producers schema classes. See [Generated Schema Classes](../README.md#generated-schema-classes)
 
-
 ## Defining Consumers
 
 Consumers are defined almost identically to producers:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,6 +46,7 @@ schema|nil|Name of the schema to use to encode data before producing.
 namespace|nil|Namespace of the schema to use when finding it locally.
 key_config|nil|Configuration hash for message keys. See [Kafka Message Keys](../README.md#installation)
 use_schema_classes|nil|Set to true or false to enable or disable using the producers schema classes. See [Generated Schema Classes](../README.md#generated-schema-classes)
+max_batch_size|500|Maximum publishing batch size. Defaults to top-level configuration of 500.
 
 ## Defining Consumers
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -198,6 +198,7 @@ producers.schema_namespace|nil|Default namespace for all producers. Can remain n
 producers.topic_prefix|nil|Add a prefix to all topic names. This can be useful if you're using the same Kafka broker for different environments that are producing the same topics.
 producers.disabled|false|Disable all actual message producing. Generally more useful to use the `disable_producers` method instead.
 producers.backend|`:kafka_async`|Currently can be set to `:db`, `:kafka`, or `:kafka_async`. If using Kafka directly, a good pattern is to set to async in your user-facing app, and sync in your consumers or delayed workers.
+producers.max_batch_size|500|Maximum batch size for publishing.
 
 ## Schema Configuration
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,7 +46,6 @@ schema|nil|Name of the schema to use to encode data before producing.
 namespace|nil|Namespace of the schema to use when finding it locally.
 key_config|nil|Configuration hash for message keys. See [Kafka Message Keys](../README.md#installation)
 use_schema_classes|nil|Set to true or false to enable or disable using the producers schema classes. See [Generated Schema Classes](../README.md#generated-schema-classes)
-max_batch_size|500|Maximum publishing batch size. Defaults to top-level configuration of 500.
 
 ## Defining Consumers
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -46,6 +46,8 @@ schema|nil|Name of the schema to use to encode data before producing.
 namespace|nil|Namespace of the schema to use when finding it locally.
 key_config|nil|Configuration hash for message keys. See [Kafka Message Keys](../README.md#installation)
 use_schema_classes|nil|Set to true or false to enable or disable using the producers schema classes. See [Generated Schema Classes](../README.md#generated-schema-classes)
+max_batch_size|500|Maximum publishing batch size. Defaults to top-level configuration of 500.
+
 
 ## Defining Consumers
 
@@ -198,7 +200,7 @@ producers.schema_namespace|nil|Default namespace for all producers. Can remain n
 producers.topic_prefix|nil|Add a prefix to all topic names. This can be useful if you're using the same Kafka broker for different environments that are producing the same topics.
 producers.disabled|false|Disable all actual message producing. Generally more useful to use the `disable_producers` method instead.
 producers.backend|`:kafka_async`|Currently can be set to `:db`, `:kafka`, or `:kafka_async`. If using Kafka directly, a good pattern is to set to async in your user-facing app, and sync in your consumers or delayed workers.
-producers.max_batch_size|500|Maximum batch size for publishing.
+producers.max_batch_size|500|Maximum batch size for publishing. Individual producers can override.
 
 ## Schema Configuration
 

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -442,7 +442,7 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       setting :replace_associations
       # Maximum publishing batch size for this producer.
       # @return [Integer]
-      setting :max_batch_size, 500
+      setting :max_batch_size
     end
 
     setting_object :consumer do

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -100,6 +100,8 @@ module Deimos # rubocop:disable Metrics/ModuleLength
             Deimos.config.consumers.bulk_import_id_generator,
           save_associations_first: kafka_config.save_associations_first
         )
+      else # producer
+        klass.config[:max_batch_size] = kafka_config.max_batch_size || Deimos.config.producers.max_batch_size
       end
     end
   end

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -344,6 +344,10 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       # sync in your consumers or delayed workers.
       # @return [Symbol]
       setting :backend, :kafka_async
+
+      # Maximum batch size for publishing.
+      # @return [Integer]
+      setting :max_batch_size, 500
     end
 
     setting :schema do

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -345,7 +345,7 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       # @return [Symbol]
       setting :backend, :kafka_async
 
-      # Maximum batch size for publishing.
+      # Maximum publishing batch size. Individual producers can override.
       # @return [Integer]
       setting :max_batch_size, 500
     end
@@ -440,6 +440,9 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       # instead of appending to them.
       # @return [Boolean]
       setting :replace_associations
+      # Maximum publishing batch size for this producer.
+      # @return [Integer]
+      setting :max_batch_size, 500
     end
 
     setting_object :consumer do

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -100,8 +100,6 @@ module Deimos # rubocop:disable Metrics/ModuleLength
             Deimos.config.consumers.bulk_import_id_generator,
           save_associations_first: kafka_config.save_associations_first
         )
-      else # producer
-        klass.config[:max_batch_size] = kafka_config.max_batch_size || Deimos.config.producers.max_batch_size
       end
     end
   end

--- a/lib/deimos/producer.rb
+++ b/lib/deimos/producer.rb
@@ -65,8 +65,7 @@ module Deimos
       def config
         @config ||= {
           encode_key: true,
-          namespace: Deimos.config.producers.schema_namespace,
-          max_batch_size: Deimos.config.producers.max_batch_size
+          namespace: Deimos.config.producers.schema_namespace
         }
       end
 
@@ -88,12 +87,6 @@ module Deimos
       # @return [String]
       def partition_key(_payload)
         nil
-      end
-
-      # @param size [Integer] Override the default batch size for publishing.
-      # @return [void]
-      def max_batch_size(size)
-        config[:max_batch_size] = size
       end
 
       # Publish the payload to the topic.

--- a/lib/deimos/producer.rb
+++ b/lib/deimos/producer.rb
@@ -59,9 +59,6 @@ module Deimos
   class Producer
     include SharedConfig
 
-    # @return [Integer]
-    MAX_BATCH_SIZE = 500
-
     class << self
 
       # @return [Hash]
@@ -126,7 +123,7 @@ module Deimos
         ) do
           messages = Array(payloads).map { |p| Deimos::Message.new(p.to_h, self, headers: headers) }
           messages.each { |m| _process_message(m, topic) }
-          messages.in_groups_of(MAX_BATCH_SIZE, false) do |batch|
+          messages.in_groups_of(Deimos.config.producers.max_batch_size, false) do |batch|
             self.produce_batch(backend_class, batch)
           end
         end

--- a/lib/deimos/producer.rb
+++ b/lib/deimos/producer.rb
@@ -65,7 +65,8 @@ module Deimos
       def config
         @config ||= {
           encode_key: true,
-          namespace: Deimos.config.producers.schema_namespace
+          namespace: Deimos.config.producers.schema_namespace,
+          max_batch_size: Deimos.config.producers.max_batch_size
         }
       end
 
@@ -87,6 +88,12 @@ module Deimos
       # @return [String]
       def partition_key(_payload)
         nil
+      end
+
+      # @param size [Integer] Override the default batch size for publishing.
+      # @return [void]
+      def max_batch_size(size)
+        config[:max_batch_size] = size
       end
 
       # Publish the payload to the topic.
@@ -123,7 +130,7 @@ module Deimos
         ) do
           messages = Array(payloads).map { |p| Deimos::Message.new(p.to_h, self, headers: headers) }
           messages.each { |m| _process_message(m, topic) }
-          messages.in_groups_of(Deimos.config.producers.max_batch_size, false) do |batch|
+          messages.in_groups_of(self.config[:max_batch_size], false) do |batch|
             self.produce_batch(backend_class, batch)
           end
         end

--- a/lib/deimos/producer.rb
+++ b/lib/deimos/producer.rb
@@ -65,7 +65,8 @@ module Deimos
       def config
         @config ||= {
           encode_key: true,
-          namespace: Deimos.config.producers.schema_namespace
+          namespace: Deimos.config.producers.schema_namespace,
+          max_batch_size: Deimos.config.producers.max_batch_size
         }
       end
 
@@ -87,6 +88,12 @@ module Deimos
       # @return [String]
       def partition_key(_payload)
         nil
+      end
+
+      # @param size [Integer] Override the default batch size for publishing.
+      # @return [void]
+      def max_batch_size(size)
+        config[:max_batch_size] = size
       end
 
       # Publish the payload to the topic.

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -616,7 +616,7 @@ module ProducerTest
     end
 
     describe "max_batch_size" do
-      it 'should default to publishing batch size of 500' do
+      it 'should use top-level default value if max_batch_size is not defined by the producer' do
         expect(MyProducer.config[:max_batch_size]).to eq(500)
       end
 


### PR DESCRIPTION
# Pull Request Template

## Description

Enabled the ability to configure `max_batch_size` on a per-producer level instead of hard-coded limit of 500. The global setting is still set to 500 by default.

Fixes [CCOL-2441](https://flippit.atlassian.net/browse/CCOL-2441)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added specs

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
