### PR TITLE
CCOL-2440: Add consumer configuration to save associated keys prior to saving primary record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 - Feature: Enable `producers.persistent_connections` phobos setting
+- Feature: Add consumer configuration, `backfill_associations` to import associated records of primary class prior to upserting primary records
 
 # 1.24.2 - 2024-05-01
 - Fix: Deprecation notice with Rails 7.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 - Feature: Enable `producers.persistent_connections` phobos setting
-- Feature: Add consumer configuration, `backfill_associations` to import associated records of primary class prior to upserting primary records
+- Feature: Add consumer configuration, `save_associations_first` to save associated records of primary class prior to upserting primary records. Foreign key of associated records are assigned to the record class prior to saving the record class
 
 # 1.24.2 - 2024-05-01
 - Fix: Deprecation notice with Rails 7.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -102,6 +102,7 @@ heartbeat_interval|10|Interval between heartbeats; must be less than the session
 backoff|`(1000..60_000)`|Range representing the minimum and maximum number of milliseconds to back off after a consumer error.
 replace_associations|nil| Whether to delete existing associations for records during bulk consumption for this consumer. If no value is specified the provided/default value from the `consumers` configuration will be used.
 bulk_import_id_generator|nil| Block to determine the `bulk_import_id` generated during bulk consumption. If no block is specified the provided/default block from the `consumers` configuration will be used.
+save_associations_first|false|Whether to save associated records of primary class prior to upserting primary records. Foreign key of associated records are assigned to the record class prior to saving the record class
 
 ## Defining Database Pollers
 

--- a/lib/deimos/active_record_consume/batch_consumption.rb
+++ b/lib/deimos/active_record_consume/batch_consumption.rb
@@ -83,7 +83,7 @@ module Deimos
       def deleted_query(records)
         keys = records.
           map { |m| record_key(m.key)[@klass.primary_key] }.
-          reject(&:nil?)
+          compact
 
         @klass.unscoped.where(@klass.primary_key => keys)
       end
@@ -168,7 +168,9 @@ module Deimos
                                   key_col_proc: key_col_proc,
                                   col_proc: col_proc,
                                   replace_associations: self.class.replace_associations,
-                                  bulk_import_id_generator: self.class.bulk_import_id_generator)
+                                  bulk_import_id_generator: self.class.bulk_import_id_generator,
+                                  backfill_associations: self.class.backfill_associations,
+                                  bulk_import_id_column: self.class.bulk_import_id_column)
         ActiveSupport::Notifications.instrument('batch_consumption.valid_records', {
                                                   records: updater.mass_update(record_list),
                                                   consumer: self.class

--- a/lib/deimos/active_record_consume/batch_consumption.rb
+++ b/lib/deimos/active_record_consume/batch_consumption.rb
@@ -169,7 +169,7 @@ module Deimos
                                   col_proc: col_proc,
                                   replace_associations: self.class.replace_associations,
                                   bulk_import_id_generator: self.class.bulk_import_id_generator,
-                                  backfill_associations: self.class.backfill_associations,
+                                  save_associations_first: self.class.save_associations_first,
                                   bulk_import_id_column: self.class.bulk_import_id_column)
         ActiveSupport::Notifications.instrument('batch_consumption.valid_records', {
                                                   records: updater.mass_update(record_list),

--- a/lib/deimos/active_record_consumer.rb
+++ b/lib/deimos/active_record_consumer.rb
@@ -45,8 +45,9 @@ module Deimos
         config[:replace_associations]
       end
 
-      def backfill_associations
-        config[:backfill_associations]
+      # @return [Boolean]
+      def save_associations_first
+        config[:save_associations_first]
       end
 
       # @param val [Boolean] Turn pre-compaction of the batch on or off. If true,

--- a/lib/deimos/active_record_consumer.rb
+++ b/lib/deimos/active_record_consumer.rb
@@ -45,6 +45,10 @@ module Deimos
         config[:replace_associations]
       end
 
+      def backfill_associations
+        config[:backfill_associations]
+      end
+
       # @param val [Boolean] Turn pre-compaction of the batch on or off. If true,
       # only the last message for each unique key in a batch is processed.
       # @return [void]

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -97,7 +97,8 @@ module Deimos # rubocop:disable Metrics/ModuleLength
                                   kafka_config.replace_associations
                                 end,
           bulk_import_id_generator: kafka_config.bulk_import_id_generator ||
-            Deimos.config.consumers.bulk_import_id_generator
+            Deimos.config.consumers.bulk_import_id_generator,
+          backfill_associations: kafka_config.backfill_associations
         )
       end
     end
@@ -475,6 +476,8 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       # specified for individual consumers
       # @return [Block]
       setting :bulk_import_id_generator, nil
+
+      setting :backfill_associations, false
 
       # These are the phobos "listener" configs. See CONFIGURATION.md for more
       # info.

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -98,7 +98,7 @@ module Deimos # rubocop:disable Metrics/ModuleLength
                                 end,
           bulk_import_id_generator: kafka_config.bulk_import_id_generator ||
             Deimos.config.consumers.bulk_import_id_generator,
-          backfill_associations: kafka_config.backfill_associations
+          save_associations_first: kafka_config.save_associations_first
         )
       end
     end
@@ -477,7 +477,10 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       # @return [Block]
       setting :bulk_import_id_generator, nil
 
-      setting :backfill_associations, false
+      # If enabled save associated records prior to saving the main record class
+      # This will also set foreign keys for associated records
+      # @return [Boolean]
+      setting :save_associations_first, false
 
       # These are the phobos "listener" configs. See CONFIGURATION.md for more
       # info.

--- a/spec/active_record_consume/mass_updater_spec.rb
+++ b/spec/active_record_consume/mass_updater_spec.rb
@@ -114,5 +114,142 @@ RSpec.describe Deimos::ActiveRecordConsume::MassUpdater do
 
       end
 
+      context 'with backfill_associations' do
+        before(:all) do
+          ActiveRecord::Base.connection.create_table(:fidgets, force: true) do |t|
+            t.string(:test_id)
+            t.integer(:some_int)
+            t.string(:bulk_import_id)
+            t.timestamps
+          end
+
+          ActiveRecord::Base.connection.create_table(:fidget_details, force: true) do |t|
+            t.string(:title)
+            t.string(:bulk_import_id)
+            t.belongs_to(:fidget)
+
+            t.index(%i(title), unique: true)
+          end
+
+          ActiveRecord::Base.connection.create_table(:widget_fidgets, force: true, id: false) do |t|
+            t.belongs_to(:fidget)
+            t.belongs_to(:widget)
+            t.string(:bulk_import_id)
+            t.string(:note)
+            t.index(%i(widget_id fidget_id), unique: true)
+          end
+        end
+
+        after(:all) do
+          ActiveRecord::Base.connection.drop_table(:fidgets)
+          ActiveRecord::Base.connection.drop_table(:fidget_details)
+          ActiveRecord::Base.connection.drop_table(:widget_fidgets)
+        end
+
+        let(:fidget_detail_class) do
+          Class.new(ActiveRecord::Base) do
+            self.table_name = 'fidget_details'
+            belongs_to :fidget
+          end
+        end
+
+        let(:fidget_class) do
+          Class.new(ActiveRecord::Base) do
+            self.table_name = 'fidgets'
+            has_one :fidget_detail
+          end
+        end
+
+        let(:widget_fidget_class) do
+          Class.new(ActiveRecord::Base) do
+            self.table_name = 'widget_fidgets'
+            belongs_to :fidget
+            belongs_to :widget
+          end
+        end
+
+        let(:bulk_id_generator) { proc { SecureRandom.uuid } }
+
+        let(:key_proc) do
+          lambda do |klass|
+            case klass.to_s
+            when 'Widget', 'Fidget'
+              %w(id)
+            when 'WidgetFidgets'
+              %w(widget_id fidget_id)
+            when 'FidgetDetail', 'Detail'
+              %w(title)
+            else
+              raise "Key Columns for #{klass} not defined"
+            end
+
+          end
+        end
+
+        before(:each) do
+          stub_const('Fidget', fidget_class)
+          stub_const('FidgetDetail', fidget_detail_class)
+          stub_const('WidgetFidgets', widget_fidget_class)
+          Widget.reset_column_information
+          Fidget.reset_column_information
+          WidgetFidgets.reset_column_information
+        end
+
+        # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+        it 'should backfill the associations when upserting primary records' do
+          batch = Deimos::ActiveRecordConsume::BatchRecordList.new(
+            [
+              Deimos::ActiveRecordConsume::BatchRecord.new(
+                klass: WidgetFidgets,
+                attributes: {
+                  widget: { test_id: 'id1', some_int: 10, detail: { title: 'Widget Title 1' } },
+                  fidget: { test_id: 'id1', some_int: 10, fidget_detail: { title: 'Fidget Title 1' } },
+                  note: 'Stuff 1'
+                },
+                bulk_import_column: 'bulk_import_id',
+                bulk_import_id_generator: bulk_id_generator
+              ),
+              Deimos::ActiveRecordConsume::BatchRecord.new(
+                klass: WidgetFidgets,
+                attributes: {
+                  widget: { test_id: 'id2', some_int: 20, detail: { title: 'Widget Title 2' } },
+                  fidget: { test_id: 'id2', some_int: 20, fidget_detail: { title: 'Fidget Title 2' } },
+                  note: 'Stuff 2'
+                },
+                bulk_import_column: 'bulk_import_id',
+                bulk_import_id_generator: bulk_id_generator
+              )
+            ]
+          )
+
+          results = described_class.new(WidgetFidgets,
+                                        bulk_import_id_generator: bulk_id_generator,
+                                        bulk_import_id_column: 'bulk_import_id',
+                                        key_col_proc: key_proc,
+                                        backfill_associations: true).mass_update(batch)
+          expect(results.count).to eq(2)
+          expect(Widget.count).to eq(2)
+          expect(Detail.count).to eq(2)
+          expect(Fidget.count).to eq(2)
+          expect(FidgetDetail.count).to eq(2)
+
+          WidgetFidgets.all.each_with_index do |widget_fidget, ind|
+            widget = Widget.find_by(id: widget_fidget.widget_id)
+            expect(widget.test_id).to eq("id#{ind + 1}")
+            expect(widget.some_int).to eq((ind + 1) * 10)
+            detail = Detail.find_by(widget_id: widget_fidget.widget_id)
+            expect(detail.title).to eq("Widget Title #{ind + 1}")
+            fidget = Fidget.find_by(id: widget_fidget.fidget_id)
+            expect(fidget.test_id).to eq("id#{ind + 1}")
+            expect(fidget.some_int).to eq((ind + 1) * 10)
+            fidget_detail = FidgetDetail.find_by(fidget_id: widget_fidget.fidget_id)
+            expect(fidget_detail.title).to eq("Fidget Title #{ind + 1}")
+            expect(widget_fidget.note).to eq("Stuff #{ind + 1}")
+          end
+        end
+        # rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength
+
+      end
+
     end
 end

--- a/spec/config/configuration_spec.rb
+++ b/spec/config/configuration_spec.rb
@@ -93,7 +93,7 @@ describe Deimos, 'configuration' do
           use_schema_classes: nil,
           max_db_batch_size: nil,
           bulk_import_id_generator: nil,
-          backfill_associations: false
+          save_associations_first: false
         }, {
           topic: 'my_batch_consume_topic',
           group_id: 'my_batch_group_id',
@@ -113,7 +113,7 @@ describe Deimos, 'configuration' do
           use_schema_classes: nil,
           max_db_batch_size: nil,
           bulk_import_id_generator: nil,
-          backfill_associations: false
+          save_associations_first: false
         }
       ],
       producer: {
@@ -268,7 +268,7 @@ describe Deimos, 'configuration' do
             use_schema_classes: false,
             max_db_batch_size: nil,
             bulk_import_id_generator: nil,
-            backfill_associations: false
+            save_associations_first: false
           }
         ],
         producer: {
@@ -300,7 +300,7 @@ describe Deimos, 'configuration' do
         group_id 'myconsumerid'
         bulk_import_id_generator(-> { 'consumer' })
         replace_associations false
-        backfill_associations true
+        save_associations_first true
       end
 
       consumer do
@@ -318,12 +318,12 @@ describe Deimos, 'configuration' do
     custom = MyConfigConsumer.config
     expect(custom[:replace_associations]).to eq(false)
     expect(custom[:bulk_import_id_generator].call).to eq('consumer')
-    expect(custom[:backfill_associations]).to eq(true)
+    expect(custom[:save_associations_first]).to eq(true)
 
     default = MyConfigConsumer2.config
     expect(default[:replace_associations]).to eq(true)
     expect(default[:bulk_import_id_generator].call).to eq('global')
-    expect(default[:backfill_associations]).to eq(false)
+    expect(default[:save_associations_first]).to eq(false)
 
   end
 end

--- a/spec/config/configuration_spec.rb
+++ b/spec/config/configuration_spec.rb
@@ -92,7 +92,8 @@ describe Deimos, 'configuration' do
           handler: 'ConsumerTest::MyConsumer',
           use_schema_classes: nil,
           max_db_batch_size: nil,
-          bulk_import_id_generator: nil
+          bulk_import_id_generator: nil,
+          backfill_associations: false
         }, {
           topic: 'my_batch_consume_topic',
           group_id: 'my_batch_group_id',
@@ -111,7 +112,8 @@ describe Deimos, 'configuration' do
           handler: 'ConsumerTest::MyBatchConsumer',
           use_schema_classes: nil,
           max_db_batch_size: nil,
-          bulk_import_id_generator: nil
+          bulk_import_id_generator: nil,
+          backfill_associations: false
         }
       ],
       producer: {
@@ -265,7 +267,8 @@ describe Deimos, 'configuration' do
             handler: 'MyConfigConsumer',
             use_schema_classes: false,
             max_db_batch_size: nil,
-            bulk_import_id_generator: nil
+            bulk_import_id_generator: nil,
+            backfill_associations: false
           }
         ],
         producer: {
@@ -297,6 +300,7 @@ describe Deimos, 'configuration' do
         group_id 'myconsumerid'
         bulk_import_id_generator(-> { 'consumer' })
         replace_associations false
+        backfill_associations true
       end
 
       consumer do
@@ -314,10 +318,12 @@ describe Deimos, 'configuration' do
     custom = MyConfigConsumer.config
     expect(custom[:replace_associations]).to eq(false)
     expect(custom[:bulk_import_id_generator].call).to eq('consumer')
+    expect(custom[:backfill_associations]).to eq(true)
 
     default = MyConfigConsumer2.config
     expect(default[:replace_associations]).to eq(true)
     expect(default[:bulk_import_id_generator].call).to eq('global')
+    expect(default[:backfill_associations]).to eq(false)
 
   end
 end


### PR DESCRIPTION
# Pull Request Template

## Description
Normal bulk consumption logic:
```Record class:
Widget:
has_one : detail
```

1. Record class records (Widget) are saved
2. Record class primary keys are filled from DB
3. Associated records (Details) are updated with foreign key from record class

Backfill consumption logic (this change)

```Record class:
FidgetWidget
belongs_to: widget
belong_to: fidget
```

Notes:
* Record class cannot be upserted first as foreign_keys `widget_id`, `fidget_id` are required

1. Associated records (Widget & Fidget) are created and linked to record class (FidgetWidget)
2. Associated records are saved
3. Primary keys (`widget_id`, `fidget_id`) of associated records are filled from DB
4. Foreign keys of record class are filled with newly saved primary keys of associated records


- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
