### PR TITLE
Add truncate_columns configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Feature: Added `producers.truncate_columns` config.
+
 ## 2.0.3 - 2025-03-12
 - Fix: `ActiveRecordProducer.config` could crash if there were non-producer configs.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -43,11 +43,12 @@ things you need to reference into local variables before calling `configure`.
 
 ### Producer Configuration
 
-| Config name            | Default        | Description                                                                                                                                                                                    |
-|------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| producers.topic_prefix | nil            | Add a prefix to all topic names. This can be useful if you're using the same Kafka broker for different environments that are producing the same topics.                                       |
-| producers.disabled     | false          | Disable all actual message producing. Generally more useful to use the `disable_producers` method instead.                                                                                     |
-| producers.backend      | `:kafka_async` | Currently can be set to `:db`, `:kafka`, or `:kafka_async`. If using Kafka directly, a good pattern is to set to async in your user-facing app, and sync in your consumers or delayed workers. |
+| Config name                | Default        | Description                                                                                                                                                                                    |
+|----------------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| producers.topic_prefix     | nil            | Add a prefix to all topic names. This can be useful if you're using the same Kafka broker for different environments that are producing the same topics.                                       |
+| producers.disabled         | false          | Disable all actual message producing. Generally more useful to use the `disable_producers` method instead.                                                                                     |
+| producers.backend          | `:kafka_async` | Currently can be set to `:db`, `:kafka`, or `:kafka_async`. If using Kafka directly, a good pattern is to set to async in your user-facing app, and sync in your consumers or delayed workers. |
+| producers.truncate_columns | false          | If set to true, will truncate values to their database limits when using KafkaSource.                                                                                                          |
 
 ### Schema Configuration
 

--- a/lib/deimos/config/configuration.rb
+++ b/lib/deimos/config/configuration.rb
@@ -133,6 +133,10 @@ module Deimos # rubocop:disable Metrics/ModuleLength
       # sync in your consumers or delayed workers.
       # @return [Symbol]
       setting :backend, :kafka_async
+
+      # If set to true, KafkaSource will automatically truncate fields to match the column
+      # length in the database.
+      setting :truncate_columns
     end
 
     setting :schema do


### PR DESCRIPTION
This adds a new configuration, `truncate_columns`. When turned on, there is a separate step that runs before sending a message via KafkaSource that truncates any values that are too long down to the limit set by the database.

This is because some databases (such as MySQL with a relaxed sql_mode) will auto-truncate values when they are saved to the database. If we don't do this step, since we are looking at the record *before* it is saved to the database, Kafka will get values that don't reflect what's actually saved in the database.