### PR TITLE
Change reference to variable instead of plain string 'kafka_topic_info'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Fix: KafkaTopicInfo: Change reference to variable instead of plain string
+
 ## 2.0.7 - 2025-03-27
 
 - Fix: Yet another crash for producers on non-producer configs.

--- a/lib/deimos/kafka_topic_info.rb
+++ b/lib/deimos/kafka_topic_info.rb
@@ -26,7 +26,7 @@ module Deimos
         # Lock the record
         qtopic = self.connection.quote(topic)
         qlock_id = self.connection.quote(lock_id)
-        qtable = self.connection.quote_table_name('kafka_topic_info')
+        qtable = self.connection.quote_table_name(self.table_name)
         qnow = self.connection.quote(quote_time(Time.zone.now))
         qfalse = self.connection.quoted_false
         qtime = self.connection.quote(quote_time(1.minute.ago))


### PR DESCRIPTION
# Pull Request Template

## Description
I want to rename table_name in Deimos::KafkaTopicInfo from 'kafka_topic_info' to 'kafka_topic_info_new'.
```ruby
Deimos::KafkaTopicInfo.class_eval do
  self.table_name = 'kafka_topic_info_new'
end
```
I discovered this issue while doing so. This reference to plain string is the bug.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Ran kafka_topic_info_spec locally

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
