### PR TITLE
Feature: Add MinimalDatadog metrics listener.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Feature: Add MinimalDatadog metrics listener.
+
 ## 2.0.9 - 2025-04-10
 
 - Fix: KafkaTopicInfo: Change reference to variable instead of plain string

--- a/lib/deimos/metrics/minimal_datadog.rb
+++ b/lib/deimos/metrics/minimal_datadog.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require 'deimos/metrics/provider'
-require 'karafka/instrumentation/vendors/datadog/metrics_listener'
-require 'waterdrop/instrumentation/vendors/datadog/metrics_listener'
+require 'deimos/metrics/datadog'
+require 'deimos/metrics/minimal_datadog_listener'
 
 module Deimos
   module Metrics

--- a/lib/deimos/metrics/minimal_datadog.rb
+++ b/lib/deimos/metrics/minimal_datadog.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'deimos/metrics/provider'
+require 'karafka/instrumentation/vendors/datadog/metrics_listener'
+require 'waterdrop/instrumentation/vendors/datadog/metrics_listener'
+
+module Deimos
+  module Metrics
+    # A Metrics wrapper class for Datadog, with only minimal metrics being sent. This will not
+    # send any rdkafka metrics, and only the following:
+    # * consumer_group
+    # * error_occurred
+    # * consumer.messages
+    # * consumer.batches
+    # * consumer.offset
+    # * consumer.consumed.time_taken
+    # * consumer.batch_size
+    # * consumer.processing_lag
+    # * consumer.consumption_lag
+    class MinimalDatadog < Deimos::Metrics::Datadog
+
+      def setup_karafka(config={})
+        karafka_listener = MinimalDatadogListener.new do |karafka_config|
+          karafka_config.client = @client
+          if config[:karafka_namespace]
+            karafka_config.namespace = config[:karafka_namespace]
+          end
+          if config[:karafka_distribution_mode]
+            karafka_config.distribution_mode = config[:karafka_distribution_mode]
+          end
+          karafka_config.rd_kafka_metrics = []
+        end
+        Karafka.monitor.subscribe(karafka_listener)
+      end
+
+    end
+  end
+end

--- a/lib/deimos/metrics/minimal_datadog_listener.rb
+++ b/lib/deimos/metrics/minimal_datadog_listener.rb
@@ -1,3 +1,6 @@
+require 'karafka/instrumentation/vendors/datadog/metrics_listener'
+require 'waterdrop/instrumentation/vendors/datadog/metrics_listener'
+
 module Deimos
   module Metrics
     class MinimalDatadogListener < ::Karafka::Instrumentation::Vendors::Datadog::MetricsListener

--- a/lib/deimos/metrics/minimal_datadog_listener.rb
+++ b/lib/deimos/metrics/minimal_datadog_listener.rb
@@ -1,0 +1,13 @@
+module Deimos
+  module Metrics
+    class MinimalDatadogListener < ::Karafka::Instrumentation::Vendors::Datadog::MetricsListener
+      # override existing listener so we don't emit metrics we don't care about
+      def on_connection_listener_fetch_loop_received(_event); end
+      def on_consumer_revoked(_event); end
+      def on_consumer_shutdown(_event); end
+      def on_consumer_ticked(_event); end
+      def on_worker_process(_event); end
+      def on_worker_processed(_event); end
+    end
+  end
+end


### PR DESCRIPTION
DataDog custom metrics can get expensive - this provides a listener that sends a much smaller set.