### PR TITLE
Fixes re logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Fix: Do not force data to JSON when logging payloads. This allows log formatters to handle the payloads on their own (e.g. adding additional fields).
+- Fix: Add topic to "Publishing Messages" log message.
+
 ## 2.0.14 - 2025-05-26
 
 - Fix: Log actual payloads by default (was logging "null" for the payload).

--- a/lib/deimos/backends/base.rb
+++ b/lib/deimos/backends/base.rb
@@ -9,9 +9,10 @@ module Deimos
         # @param messages [Array<Hash>]
         # @return [void]
         def publish(producer_class:, messages:)
+          topic = producer_class.topic
           execute(producer_class: producer_class, messages: messages)
           message = ::Deimos::Logging.messages_log_text(producer_class.karafka_config.payload_log, messages)
-          Deimos::Logging.log_info({message: 'Publishing Messages:'}.merge(message))
+          Deimos::Logging.log_info({message: "Publishing Messages for #{topic}:" }.merge(message))
         end
 
         # @param producer_class [Class<Deimos::Producer>]

--- a/lib/deimos/logging.rb
+++ b/lib/deimos/logging.rb
@@ -5,10 +5,10 @@ module Deimos
       def log_add(method, msg)
         if Karafka.logger.respond_to?(:tagged)
           Karafka.logger.tagged('Deimos') do |logger|
-            logger.send(method, msg.to_json)
+            logger.send(method, msg)
           end
         else
-          Karafka.logger.send(method, msg.to_json)
+          Karafka.logger.send(method, msg)
         end
       end
 

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -283,15 +283,15 @@ module ProducerTest
             ]
           )
           expect(Karafka.logger).to have_received(:info).with(match_message({
-            'message' => 'Publishing Messages:',
-            'payloads' => [
+            message: 'Publishing Messages for my-topic-with-id:',
+            payloads: [
               {
-                'payload' => { 'test_id' => 'foo', 'some_int' => 123 },
-                'key' => 'key'
+                payload: { 'test_id' => 'foo', 'some_int' => 123 },
+                key: 'key'
               },
               {
-                'payload' => { 'test_id' => 'foo2', 'some_int' => 123 },
-                'key' => 'key2'
+                payload: { 'test_id' => 'foo2', 'some_int' => 123 },
+                key: 'key2'
               }
             ]
           }))
@@ -309,8 +309,8 @@ module ProducerTest
             ]
           )
           expect(Karafka.logger).to have_received(:info).with(match_message({
-            'message' => 'Publishing Messages:',
-            'payloads_count' => 2
+            message: 'Publishing Messages for my-topic-with-id:',
+            payloads_count: 2
           }))
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -347,14 +347,13 @@ end
 RSpec::Matchers.define :match_message do |msg|
   match do |actual|
     begin
-      parsed = JSON.parse(actual)
-      parsed['payloads']&.each do |p|
-        p['payload'].delete('timestamp')
-        p['payload'].delete('message_id')
+      return false unless actual.is_a?(Hash)
+
+      actual[:payloads]&.each do |p|
+        p[:payload].delete('timestamp')
+        p[:payload].delete('message_id')
       end
-      expect(parsed).to match(a_hash_including(msg))
-    rescue JSON::ParserError
-      false
+      expect(actual).to match(a_hash_including(msg))
     end
   end
 end


### PR DESCRIPTION
- Fix: Do not force data to JSON when logging payloads. This allows log formatters to handle the payloads on their own (e.g. adding additional fields).
- Fix: Add topic to "Publishing Messages" log message.
