### PR TITLE
Fix: Send `publish` metric even if the producer was not a Deimos prod…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Fix: Send `publish` metric even if the producer was not a Deimos producer.
+
 ## 2.0.15 - 2025-05-29
 
 - Fix: Do not force data to JSON when logging payloads. This allows log formatters to handle the payloads on their own (e.g. adding additional fields).

--- a/lib/deimos.rb
+++ b/lib/deimos.rb
@@ -25,6 +25,7 @@ require 'deimos/ext/schema_route'
 require 'deimos/ext/consumer_route'
 require 'deimos/ext/producer_route'
 require 'deimos/ext/producer_middleware'
+require 'deimos/ext/producer_metrics_listener'
 require 'deimos/ext/routing_defaults'
 
 require 'deimos/railtie' if defined?(Rails)
@@ -145,6 +146,8 @@ module Deimos
       Karafka.producer.config.kafka =
         Karafka::Setup::AttributesMap.producer(Karafka::Setup::Config.config.kafka.dup)
       EVENT_TYPES.each { |type| Karafka.monitor.notifications_bus.register_event(type) }
+
+      Karafka.producer.monitor.subscribe(ProducerMetricsListener.new)
 
       Karafka.producer.monitor.subscribe('error.occurred') do |event|
         if event.payload.key?(:messages)

--- a/lib/deimos/backends/kafka.rb
+++ b/lib/deimos/backends/kafka.rb
@@ -7,11 +7,6 @@ module Deimos
       # :nodoc:
       def self.execute(producer_class:, messages:)
         Karafka.producer.produce_many_sync(messages)
-        Deimos.config.metrics&.increment(
-          'publish',
-          tags: %W(status:success topic:#{messages.first[:topic]}),
-          by: messages.size
-        )
       end
     end
   end

--- a/lib/deimos/backends/kafka_async.rb
+++ b/lib/deimos/backends/kafka_async.rb
@@ -7,11 +7,6 @@ module Deimos
       # :nodoc:
       def self.execute(producer_class:, messages:)
         Karafka.producer.produce_many_async(messages)
-        Deimos.config.metrics&.increment(
-          'publish',
-          tags: %W(status:success topic:#{messages.first[:topic]}),
-          by: messages.size
-        )
       end
     end
   end

--- a/lib/deimos/ext/producer_metrics_listener.rb
+++ b/lib/deimos/ext/producer_metrics_listener.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Deimos
+  class ProducerMetricsListener
+      %i[
+        produced_sync
+        produced_async
+      ].each do |event_scope|
+        define_method(:"on_message_#{event_scope}") do |event|
+          Deimos.config.metrics&.increment(
+            'publish',
+            tags: %W(status:success topic:#{event[:message][:topic]})
+          )
+        end
+
+        define_method(:"on_messages_#{event_scope}") do |event|
+          Deimos.config.metrics&.increment(
+            'publish',
+            tags: %W(status:success topic:#{event[:messages].first[:topic]}),
+            by: event[:messages].size
+          )
+        end
+      end
+  end
+end


### PR DESCRIPTION
…ucer.

Previously, the `publish` metric was only sent as part of the publish backend, meaning someone had to call `publish` on an actual Deimos producer instance. This is no longer required since so much of the producer logic goes through Karafka middleware, and it didn't work with the messages being sent by the outbox backend.

This introduces a separate listener that integrates with Karafka, so it will always send these metrics.
