### PR TITLE
Make schema classes backwards-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Fix: Allow schema classes to be used with backwards-compatible Avro messages.
+
 ## 2.0.17 - 2025-07-03
 
 - Feature: Allow producers to specify `:message` and `:key` in the `publish` methods.

--- a/lib/deimos/schema_class/enum.rb
+++ b/lib/deimos/schema_class/enum.rb
@@ -39,7 +39,7 @@ module Deimos
       end
 
       # @return [SchemaClass::Enum]
-      def self.initialize_from_value(value)
+      def self.initialize_from_value(value, from_message: false)
         return nil if value.nil?
 
         value.is_a?(self) ? value : self.new(value)

--- a/lib/deimos/utils/schema_class.rb
+++ b/lib/deimos/utils/schema_class.rb
@@ -43,7 +43,7 @@ module Deimos
           klass = klass(schema, namespace)
           return payload if klass.nil? || payload.nil?
 
-          klass.new(**payload.symbolize_keys)
+          klass.new_from_message(**payload.symbolize_keys)
         end
 
         # Determine and return the SchemaClass with the provided schema and namespace

--- a/lib/generators/deimos/schema_class/templates/schema_record.rb.tt
+++ b/lib/generators/deimos/schema_class/templates/schema_record.rb.tt
@@ -49,8 +49,9 @@
     <%- @field_assignments.select{ |h| h[:is_complex_union] }.each do |method_definition| -%>
     # Helper method to determine which schema type to use for <%= method_definition[:field].name %>
     # @param value [Hash, nil]
+    # @param from_message [Boolean] whether this was initialized from a real Avro message
     # @return [Object, nil]
-    def initialize_<%= method_definition[:field].name %>_type(value)
+    def initialize_<%= method_definition[:field].name %>_type(value, from_message: false)
       return nil if value.nil?
 
       klass = [<%= method_definition[:field].type.schemas.reject { |s| s.type_sym == :null }.select { |s| s.type_sym == :record }.map { |s| Deimos::SchemaBackends::AvroBase.schema_classname(s) }.join(', ') %>].find do |candidate|
@@ -58,7 +59,7 @@
         (value.keys - fields).empty?
       end
 
-      klass.initialize_from_value(value)
+      klass.initialize_from_value(value, from_message: @from_message)
     end
 
     <%- end -%>

--- a/lib/generators/deimos/schema_class_generator.rb
+++ b/lib/generators/deimos/schema_class_generator.rb
@@ -245,7 +245,7 @@ module Deimos
           "record.tombstone_key = key\n      record.#{key_config[:field]} = key"
         elsif key_schema
           field_base_type = _field_type(key_schema)
-          "record.tombstone_key = #{field_base_type}.initialize_from_value(key)\n      record.payload_key = key"
+          "record.tombstone_key = #{field_base_type}.initialize_from_value(key, from_message: @from_message)\n      record.payload_key = key"
         else
           ''
         end
@@ -299,9 +299,9 @@ module Deimos
           field_initialization = method_argument
 
           if _is_complex_union?(field)
-            field_initialization = "initialize_#{field.name}_type(value)"
+            field_initialization = "initialize_#{field.name}_type(value, from_message: @from_message)"
           elsif is_schema_class
-            field_initialization = "#{field_base_type}.initialize_from_value(value)"
+            field_initialization = "#{field_base_type}.initialize_from_value(value, from_message: @from_message)"
           end
 
           result << {


### PR DESCRIPTION
Avro compatibility allows for adding fields with a default. When this happens, schema classes will crash because it doesn't recognize the field in the `initialize` method.

This change updates how the consumer specifically instantiates these messages so it simply ignores any fields it doesn't know about.