### PR TITLE
Fix: Allows rails to handle querying bulk_import_id when replacing associations for non-string bulk_import_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## UNRELEASED
+- Fix: Allows rails to handle querying bulk_import_id when replacing associations for non-string bulk_import_ids
 
 # 2.1.5 - 2025-07-23
 

--- a/lib/deimos/active_record_consume/batch_record_list.rb
+++ b/lib/deimos/active_record_consume/batch_record_list.rb
@@ -76,10 +76,9 @@ module Deimos
         return if self.batch_records.none?
 
         primary_keys = self.primary_keys(assoc.name)
-        assoc.klass.
-          where(assoc.foreign_key => primary_keys).
-          where("#{self.bulk_import_column} != ?", import_id).
-          delete_all
+        assoc.klass.where(assoc.foreign_key => primary_keys).merge(
+          assoc.klass.where.not(self.bulk_import_column => import_id)
+        ).delete_all
       end
 
     end


### PR DESCRIPTION
# Pull Request Template

## Description
When `bulk_import_ids` are stored in a non-string column (eg, binary) the resulting query from `delete_old_records` would force the string representation of that column instead of allowing Rails and corresponding attribute libraries to do the appropriate conversions.  

Fixes # (issue)
- Fix: Allows rails to handle querying bulk_import_id when replacing associations for non-string bulk_import_ids

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Was previously monkey-patched to use with the https://github.com/k2nr/ulid-rails library for `bulk_import_id`

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
