### PR TITLE
CPFM-3243-part2 Fix send_kafka_event_on_update for models have multiple producers to only send a message if field changed exists in the current producer watched attribute only 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Fix: When a model uses multiple producers, `send_kafka_event_on_update` no longer aggregates `watched_attributes` across all producers and publishes to all of them if any field changed. It now evaluates each producer’s `watched_attributes` independently and publishes only to the producers whose fields changed (per‑producer isolation).
+
 # 2.1.8 - 2025-08-11
 
 - Feature: Producers can now customize the deletion payload, so different producers using the same model can send different delete messages.


### PR DESCRIPTION
# Pull Request Template

## Description

Fix send_kafka_event_on_update for models have multiple producers to only send a message if field changed exists in the current producer watched attribute only 
- updated send_kafka_event_on_update 
- Add rspec to the change

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
