### PR TITLE
Feature: Added `delete_record?` method to ActiveRecordConsumer to all…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release Gem
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*' # Matches semantic versioning tags like v1.0.0
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Feature: Added `delete_record?` method to ActiveRecordConsumer to allow inspection of the payload to decide whether to delete, instead of hardcoding it to only delete on a null payload.
+
 # 2.1.9 - 2025-08-13
 
 - Fix: When a model uses multiple producers, `send_kafka_event_on_update` no longer aggregates `watched_attributes` across all producers and publishes to all of them if any field changed. It now evaluates each producer’s `watched_attributes` independently and publishes only to the producers whose fields changed (per‑producer isolation).

--- a/README.md
+++ b/README.md
@@ -498,6 +498,12 @@ class MyConsumer < Deimos::ActiveRecordConsumer
   def destroy_record(record)
     super
   end
+  
+  # Optional override of the logic determining whether to delete the record. Default is to
+  # delete it if the payload is nil.
+  def delete_record?(record)
+    super
+  end
  
   # Optional override to change the attributes of the record before they
   # are saved.

--- a/lib/deimos/active_record_consume/batch_consumption.rb
+++ b/lib/deimos/active_record_consume/batch_consumption.rb
@@ -125,7 +125,7 @@ module Deimos
       def update_database(messages)
         # Find all upserted records (i.e. that have a payload) and all
         # deleted record (no payload)
-        removed, upserted = messages.partition(&:tombstone?)
+        removed, upserted = messages.partition { |m| delete_record?(m) }
 
         max_db_batch_size = self.class.config[:max_db_batch_size]
         if upserted.any?

--- a/lib/deimos/active_record_consume/message_consumption.rb
+++ b/lib/deimos/active_record_consume/message_consumption.rb
@@ -42,7 +42,7 @@ module Deimos
 
         klass = self.class.config[:record_class]
         record = fetch_record(klass, message.payload.to_h.with_indifferent_access, message.key)
-        if message.payload.nil?
+        if delete_record?(message)
           destroy_record(record)
           return
         end

--- a/lib/deimos/active_record_consumer.rb
+++ b/lib/deimos/active_record_consumer.rb
@@ -95,6 +95,14 @@ module Deimos
       self.converter.convert(payload)
     end
 
+    # Indicates whether to delete the given message. Defaults to checking if the message
+    # payload is nil.
+    # @param message [Deimos::Message]
+    # @return [Boolean]
+    def delete_record?(message)
+      message.payload.nil?
+    end
+
     # Override this message to conditionally save records
     # @param _payload [Hash,Deimos::SchemaClass::Record] The kafka message
     # @return [Boolean] if true, record is created/update.

--- a/lib/deimos/version.rb
+++ b/lib/deimos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Deimos
-  VERSION = '2.1.9'
+  VERSION = '2.1.10'
 end


### PR DESCRIPTION
…ow inspection of the payload to decide whether to delete, instead of hardcoding it to only delete on a null payload.

Also added a release.yml to mirror other gems, which allows pushing directly to RubyGems instead of me doing it locally.