### PR TITLE
Fix: import_associations reuses stale parent id on DeadlockRetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix: `BatchRecordList#fill_primary_keys!` no longer short-circuits on stale in-memory primary keys left over from a rolled-back `DeadlockRetry` attempt, preventing `ActiveRecord::InvalidForeignKey` during association imports.
+
 ## 2.5.1 - 2026-03-18
 
 - Fix: Outbox producer would swallow ActiveRecord errors except for uniqueness.

--- a/lib/deimos/active_record_consume/batch_record.rb
+++ b/lib/deimos/active_record_consume/batch_record.rb
@@ -16,6 +16,8 @@ module Deimos
       attr_accessor :bulk_import_id
       # @return [String] The column name to use for bulk IDs - defaults to `bulk_import_id`.
       attr_accessor :bulk_import_column
+      # @return [Boolean] true if the primary key was supplied in the input attributes,
+      attr_accessor :primary_key_preset
 
       delegate :valid?, :errors, :send, :attributes, to: :record
 
@@ -32,6 +34,7 @@ module Deimos
         end
         attributes = attributes.with_indifferent_access
         self.record = klass.new(attributes.slice(*klass.column_names))
+        self.primary_key_preset = !self.record[klass.primary_key].nil?
         assoc_keys = attributes.keys.select { |k| klass.reflect_on_association(k) }
         # a hash with just the association keys, removing all actual column information.
         self.associations = attributes.slice(*assoc_keys)

--- a/lib/deimos/active_record_consume/batch_record_list.rb
+++ b/lib/deimos/active_record_consume/batch_record_list.rb
@@ -53,7 +53,8 @@ module Deimos
       def fill_primary_keys!
         primary_col = self.klass.primary_key
 
-        return if self.batch_records.empty? || self.batch_records.first.send(primary_col).present?
+        # Skip if nothing to backfill or caller already supplied the PK.
+        return if self.batch_records.empty? || self.batch_records.first.primary_key_preset
 
         bulk_import_map = self.klass.
           where(self.bulk_import_column => self.batch_records.map(&:bulk_import_id)).

--- a/spec/active_record_consume/mass_updater_spec.rb
+++ b/spec/active_record_consume/mass_updater_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Deimos::ActiveRecordConsume::MassUpdater do
           detail_call_count = 0
           allow(Detail).to receive(:import!).and_wrap_original do |m, *args|
             detail_call_count += 1
-            raise ActiveRecord::Deadlocked.new('Lock wait timeout exceeded') if detail_call_count == 1
+            raise ActiveRecord::Deadlocked, 'Lock wait timeout exceeded' if detail_call_count == 1
 
             m.call(*args)
           end

--- a/spec/active_record_consume/mass_updater_spec.rb
+++ b/spec/active_record_consume/mass_updater_spec.rb
@@ -112,6 +112,34 @@ RSpec.describe Deimos::ActiveRecordConsume::MassUpdater do
           expect(Detail.count).to eq(0)
         end
 
+        it 'should refetch parent primary keys when retrying child import' do
+          allow(Widget).to receive(:import!).and_call_original
+          allow(Widget).to receive(:where).and_call_original
+
+          # Deadlock the first child import to trigger DeadlockRetry; let the retry pass through.
+          detail_call_count = 0
+          allow(Detail).to receive(:import!).and_wrap_original do |m, *args|
+            detail_call_count += 1
+            raise ActiveRecord::Deadlocked.new('Lock wait timeout exceeded') if detail_call_count == 1
+
+            m.call(*args)
+          end
+
+          described_class.new(Widget, bulk_import_id_generator: bulk_id_generator).mass_update(batch)
+
+          # Parent ids written by `fill_primary_keys!` during attempt 1 stay in
+          # memory after the DB rollback, so they're stale on retry. Assert the
+          # retry re-queries. Outcome-level checks are unreliable: SQLite reuses
+          # rolled-back ids so stale memory matches coincidentally; MySQL and
+          # Postgres burn auto-increment and surface ActiveRecord::InvalidForeignKey.
+          expect(Widget).to have_received(:where).
+            with(bulk_import_id: [instance_of(String), instance_of(String)]).twice
+          expect(Widget.count).to eq(2)
+          expect(Detail.count).to eq(2)
+          expect(Widget.first.detail).not_to be_nil
+          expect(Widget.last.detail).not_to be_nil
+        end
+
       end
 
       context 'with save_associations_first' do


### PR DESCRIPTION
## Description

In the non-`save_associations_first` path of `MassUpdater#mass_update`, a deadlock on a child import (not on the parent) leaves the in-memory `record[primary_col]` populated after the transaction rolls back. That value was written by `fill_primary_keys!` during attempt 1. The existing guard `record[primary_col].present?` then short-circuits `fill_primary_keys!` on retry, and child records are built with the stale parent id.

In DBs that burn auto-increment on rollback (MySQL InnoDB, Postgres), the retry's parent INSERT lands on a different id and the child INSERT raises `ActiveRecord::InvalidForeignKey`.

```
Attempt 1
BEGIN TRANSACTION
  Step 1: INSERT parent → id = 202 in the DB
  Step 2: fill_primary_keys! → Ruby object now holds "parent.id = 202"
  Step 3: INSERT details → ok
  Step 4: INSERT distributions → DEADLOCK
ROLLBACK
After the rollback:
- In the DB: parent row 202 is gone (it was rolled back)
- In Ruby memory: the parent object still says "parent.id = 202"
- In MySQL: the counter that assigns IDs does not rewind. Next INSERT will get 203, not 202.
Attempt 2 (Deimos automatically retries after a deadlock)
BEGIN TRANSACTION
  Step 1: INSERT parent → id = 203 in the DB (because 202 was used up)
  Step 2: fill_primary_keys! → SKIPPED (Deimos checks "is parent.id already set in memory?" → yes, 202 → skips the lookup)
  Step 3: INSERT details with generic_offer_id = 202 → FOREIGN KEY FAILS (no row 202 exists, real parent is at 203)
ROLLBACK
```
We saw this on item-platform's print offer consumer - [Datadog trace](https://app.datadoghq.com/dashboard/py5-397-mkp?query=service%3Aitem_platform%20AND%20env%3Aproduction%20AND%20resource_name%3AKafka-PrintOfferConsumer%20operation_name%3Adeimos_consumer%20status%3Aerror&event=AwAAAZ2XwK7Yh_o_xQAAABhBWjJYd0xjTkFBQmhrMVFQMGRfQjNKczkAAABdMTE5ZDk3YzUtZTQ3MS00MmFlLWIwNGEtOGNhYmI3ZmZlNjIzLXN5bnRoZXRpYy10aW1lLTE3NzYzNjYwMDAwMDAwMDAwMDBjLTE3NzYzNjc4MjE5MzcwMDAwMDFvAAEBcg&fromUser=true&graphType=waterfall&historicalData=true&index=&panelFrom=1776366000000&panelTo=1776367800000&panelType=trace&refresh_mode=paused&shouldShowLegend=true&spanID=1835490373513295316&traceID=4439143481304951882&traceQuery=&view=spans&from_ts=1776272065872&to_ts=1776368241000&live=false), noticed that 5-error pattern in the trace with the first error being the deadlock and the final error that got surfaced being the Fk error.

## Fix

BatchRecord captures `primary_key_preset` at construction time. `fill_primary_keys!`'s guard short-circuits on that flag instead of on the live record[primary_col] value, since it can be stale. The existing optimization for user-supplied PKs is preserved, and retries ALWAYS get a fresh id lookup.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Rspec
- [x] Using item-platform PrintOfferConsumer (where the bug was originally found)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
