### PR TITLE
fix/karafka-producer-overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix: `setup_karafka` applies the merged kafka config to `Karafka.producer`, so kafka overrides set in later `Karafka::App.setup` calls take effect on `Karafka.producer` callers (Karafka::Web, DLQ, ActiveJob).
+
 ## 2.5.2 - 2026-04-24
 
 - Fix: `BatchRecordList#fill_primary_keys!` no longer short-circuits on stale in-memory primary keys left over from a rolled-back `DeadlockRetry` attempt, preventing `ActiveRecord::InvalidForeignKey` during association imports.

--- a/lib/deimos.rb
+++ b/lib/deimos.rb
@@ -191,14 +191,14 @@ module Deimos
         end
         @producers[topic.name] = producers_by_broker[broker]
       end
-    end
-
-    def setup_karafka
-      setup_producers
       # Karafka.producer's kafka config is captured at first Karafka::App.setup;
       # apply the merged global so later overrides actually take effect.
       Karafka.producer.config.kafka =
         Karafka::Setup::AttributesMap.producer(Karafka::Setup::Config.config.kafka.dup)
+    end
+
+    def setup_karafka
+      setup_producers
       waterdrop_producers.each do |producer|
         producer.middleware.append(Deimos::ProducerMiddleware)
         producer.monitor.subscribe(ProducerMetricsListener.new)

--- a/lib/deimos.rb
+++ b/lib/deimos.rb
@@ -195,6 +195,10 @@ module Deimos
 
     def setup_karafka
       setup_producers
+      # Karafka.producer's kafka config is captured at first Karafka::App.setup;
+      # apply the merged global so later overrides actually take effect.
+      Karafka.producer.config.kafka =
+        Karafka::Setup::AttributesMap.producer(Karafka::Setup::Config.config.kafka.dup)
       waterdrop_producers.each do |producer|
         producer.middleware.append(Deimos::ProducerMiddleware)
         producer.monitor.subscribe(ProducerMetricsListener.new)


### PR DESCRIPTION
## Description

Re-applies the merged kafka config to `Karafka.producer` at the end of `Deimos.setup_karafka`. 

Without this line, apps that build kafka config across multiple `Karafka::App.setup` calls leave `Karafka.producer` on its first-setup snapshot — overrides like `request.required.acks` never reach it, and callers that still go through the singleton (`Karafka::Web` tracking reports, DLQ, ActiveJob) silently fall back to librdkafka defaults.

Manifested in `item-platform` after upgrading 2.1.13 → 2.5.2 as a `librdkafka.dispatch_error / msg_timed_out` flood from `Karafka::Web` reports on every consumer pod.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Full existing rspec suite passes locally (`bundle exec rspec` — 360 examples, 0 failures)
- [x] Verified by applying the equivalent re-sync in `item-platform`'s `karafka.rb` — staging consumer pods went from thousands of `msg_timed_out / librdkafka.dispatch_error` events per minute to zero immediately after the change took effect.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not applicable — internal behavior, no public API change)
- [x] I have added a line in the CHANGELOG describing this change, under the UNRELEASED heading
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (not applicable)