### PR TITLE
Fix: coerce DeadlockRetry tags to array to keep retry working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix: `DeadlockRetry.wrap` coerces its `tags` argument with `Array(...)`, so a scalar topic String (passed by `MassUpdater`/batch consumption) no longer raises `NoMethodError` on `String#to_a` inside the rescue, which had defeated the deadlock retry on the first deadlock.
+
 ## 2.5.3 - 2026-04-28
 
 - Fix: `setup_karafka` applies the merged kafka config to `Karafka.producer`, so kafka overrides set in later `Karafka::App.setup` calls take effect on `Karafka.producer` callers (Karafka::Web, DLQ, ActiveJob).

--- a/lib/deimos/utils/deadlock_retry.rb
+++ b/lib/deimos/utils/deadlock_retry.rb
@@ -28,10 +28,15 @@ module Deimos
         # be wrapped in a transaction.
         # Sleeps for a random number of seconds to prevent multiple transactions
         # from retrying at the same time.
-        # @param tags [Array] Tags to attach when logging and reporting metrics.
+        # @param tags [Array, String, nil] Tags to attach when logging and reporting metrics.
+        #   A scalar (e.g. a topic String) is coerced to a single-element array.
         # @yield Yields to the block that may deadlock.
         # @return [void]
         def wrap(tags=[])
+          # Normalize to an Array so downstream logging/metrics (and dogstatsd's
+          # `tags.to_a`) never receive a bare String, which would raise
+          # NoMethodError inside this rescue and defeat the retry mechanism.
+          tags = Array(tags)
           count = RETRY_COUNT
 
           begin

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -62,7 +62,7 @@ module ConsumerTest
                                  'some_int' => 123 }) do |payload, _metadata|
                                    expect(payload['test_id']).to eq('foo')
                                    expect(payload['some_int']).to eq(123)
-                                 end
+            end
           end
 
           it 'should consume a nil message' do
@@ -77,7 +77,7 @@ module ConsumerTest
                                  'some_int' => 123 }) do |payload, _metadata|
                                    expect(payload['test_id']).to eq('foo')
                                    expect(payload['some_int']).to eq(123)
-                                 end
+            end
           end
 
           it 'should fail on invalid message' do
@@ -196,7 +196,7 @@ module ConsumerTest
             expect(payload['test_id']).to eq('foo')
             expect(payload['some_int']).to eq(1)
             expect(payload['super_int']).to eq(9000)
-                                 end
+          end
         end
 
       end
@@ -255,7 +255,7 @@ module ConsumerTest
             expect(payload['some_nested_record']['some_int']).to eq(1)
             expect(payload.to_h).not_to have_key('additional_field')
             expect(payload.to_h['some_nested_record']).not_to have_key('additional_field')
-                                 end
+          end
 
         end
       end

--- a/spec/utils/deadlock_retry_spec.rb
+++ b/spec/utils/deadlock_retry_spec.rb
@@ -55,6 +55,26 @@ RSpec.describe Deimos::Utils::DeadlockRetry do
       expect(Widget.all).to contain_exactly(have_attributes(test_id: 'first'), have_attributes(test_id: 'second'))
     end
 
+    it 'should coerce a scalar tag to an array when reporting metrics' do
+      # Regression: mass_updater passes get_tag('topic') (a String) as tags.
+      # dogstatsd calls tags.to_a, which raises NoMethodError on a String and
+      # would defeat the retry mechanism on the first deadlock.
+      metrics = instance_double(Deimos::Metrics::Provider)
+      allow(Deimos.config).to receive(:metrics).and_return(metrics)
+      expect(metrics).to receive(:increment).with('deadlock', tags: ['Flyers.FlyerItem']).twice
+
+      expect(Widget).
+        to receive(:create).
+        and_raise(ActiveRecord::Deadlocked.new('Lock wait timeout exceeded')).
+        exactly(3).times
+
+      expect {
+        described_class.wrap('Flyers.FlyerItem') do
+          Widget.create(test_id: 'abc')
+        end
+      }.to raise_error(ActiveRecord::Deadlocked)
+    end
+
     it 'should not retry non-deadlock exceptions' do
       expect(Widget).
         to receive(:create).


### PR DESCRIPTION
## Problem

`content-sieve-consumer` (prod) was logging `Error consuming message batch` → `undefined method 'to_a' for an instance of String` on the hot `FlyerItemConsumer` / `Flyers.FlyerItem` batch-upsert path.

Root cause is a bug in the deadlock-retry path, surfaced by dogstatsd-ruby 3.0.0:

1. `MassUpdater#mass_update` and `BatchConsumption` call `DeadlockRetry.wrap(...get_tag('topic'))`, passing a **String** (e.g. `"Flyers.FlyerItem"`).
2. `wrap`'s `tags` param is documented `@param tags [Array]`; on a deadlock it forwards `tags` straight to `Deimos.config.metrics&.increment('deadlock', tags: tags)`.
3. dogstatsd 3.0.0's `send_stats` calls `opts[:tags].to_a` — and `String#to_a` does not exist in Ruby 3.x → `NoMethodError`.

Because that raise happens **inside the rescue, before `count -= 1` and the retry**, the first deadlock immediately became a hard batch failure instead of being retried up to `RETRY_COUNT` times. The deadlock-retry mechanism was defeated on exactly the deadlock-prone path it exists to protect.

## Fix

Normalize the argument with `Array(tags)` at the top of `DeadlockRetry.wrap`. One change fixes all four call sites and is robust to a scalar String, `nil`, or an already-correct Array.

## Testing

- Added a regression spec that passes a String tag through `wrap` on a deadlock and asserts the metric is incremented with the coerced array — this raised `NoMethodError` before the fix.
- `bundle exec rspec spec/utils/deadlock_retry_spec.rb` → 4 examples, 0 failures.
- `bundle exec rubocop` on the changed files → no offenses.
- CHANGELOG updated under `Unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)